### PR TITLE
perf(packages/eg-walker): spread the checkpoint ladder and adapt the replay-cache budget

### DIFF
--- a/packages/eg-walker/src/core/internals/critical-checkpoint-store.ts
+++ b/packages/eg-walker/src/core/internals/critical-checkpoint-store.ts
@@ -271,11 +271,56 @@ export class CriticalCheckpointStore {
   private append(checkpoint: CriticalCheckpoint): void {
     const next = [...this.checkpoints, checkpoint];
     this.checkpoints =
-      next.length <= MAX_RETAINED_CHECKPOINTS
-        ? next
-        : next.slice(next.length - MAX_RETAINED_CHECKPOINTS);
+      next.length <= MAX_RETAINED_CHECKPOINTS ? next : thinCheckpoints(next);
   }
 }
+
+/**
+ * Thin the retained ladder instead of keeping the newest cuts.
+ *
+ * `maybeAdvance` records one checkpoint per incrementally applied event, so a
+ * plain "keep the newest `MAX_RETAINED_CHECKPOINTS`" window collapses into 32
+ * consecutive cuts: the store ends up covering ~31 events of history and every
+ * divergence reaching further back misses and falls into a full replay.
+ *
+ * Evict the interior cut whose removal costs least instead. Cost is the gap the
+ * removal opens, relative to how far that cut sits behind the head: a wide gap
+ * deep in history is cheap, the same gap next to the head is not. Repeated
+ * application keeps recent cuts dense while old gaps grow geometrically, so a
+ * divergence at depth `d` still finds a checkpoint within a small factor of `d`.
+ * The oldest and newest entries are never evicted — they anchor the ladder.
+ */
+const thinCheckpoints = (
+  checkpoints: ReadonlyArray<CriticalCheckpoint>,
+): ReadonlyArray<CriticalCheckpoint> => {
+  const last = checkpoints[checkpoints.length - 1];
+  if (checkpoints.length < 3 || last === undefined) {
+    return checkpoints.slice(checkpoints.length - MAX_RETAINED_CHECKPOINTS);
+  }
+  const head = last.eventCount;
+  let victim = 1;
+  let lowestCost = Number.POSITIVE_INFINITY;
+  for (let index = 1; index < checkpoints.length - 1; index++) {
+    const previous = checkpoints[index - 1];
+    const current = checkpoints[index];
+    const following = checkpoints[index + 1];
+    if (
+      previous === undefined ||
+      current === undefined ||
+      following === undefined
+    ) {
+      continue;
+    }
+    const gap = following.eventCount - previous.eventCount;
+    const depth = head - current.eventCount + 1;
+    const cost = gap / depth;
+    if (cost < lowestCost) {
+      lowestCost = cost;
+      victim = index;
+    }
+  }
+  return checkpoints.filter((_, index) => index !== victim);
+};
 
 const versionsEqual = (
   left: ReadonlySet<EventId>,

--- a/packages/eg-walker/src/core/replica.ts
+++ b/packages/eg-walker/src/core/replica.ts
@@ -131,6 +131,20 @@ export interface CreateNativeSnapshotOptions {
 const REPLAY_CACHE_CRITICAL_RELEASE_EVENTS = 4_096;
 const MAX_WARM_BATCH_EVENTS = 4_096;
 const MAX_REPLAY_CACHE_BYTES = 32 * 1024 * 1024;
+/**
+ * Ceiling for the adaptive replay-cache budget.
+ *
+ * The base budget is sized for ordinary editing. A concurrent interval that
+ * legitimately spans a whole document needs one sequence record per code unit,
+ * so on merge-heavy histories the base budget can sit *below* the interval's
+ * intrinsic floor: the engine is refused, the next event rebuilds the same
+ * interval from scratch, and the replica thrashes one full replay per batch
+ * while never actually holding less memory. When that happens the budget grows
+ * (see {@link EgWalkerReplica.growReplayCacheBudgetAfterThrash}); this ceiling
+ * stops the growth so a peer streaming an unboundedly large concurrent
+ * interval still releases its cache.
+ */
+const MAX_REPLAY_CACHE_BUDGET_BYTES = 8 * MAX_REPLAY_CACHE_BYTES;
 const ESTIMATED_REPLAY_RECORD_BYTES = 256;
 const ESTIMATED_DELETE_TARGET_BYTES = 32;
 // Keep a short causally-linear gap inside one obsolete nonlinear replay
@@ -249,6 +263,10 @@ export class EgWalkerReplica {
   private snapshotValidationStats = { replays: 0, events: 0, linearReplays: 0 };
   private replayCacheEvents = 0;
   private replayCacheBytes = 0;
+  /** Adaptive budget; grows only after a refusal forced a full rebuild. */
+  private replayCacheBudgetBytes = MAX_REPLAY_CACHE_BYTES;
+  /** True while a byte-budget refusal has not yet been paid for by a replay. */
+  private releasedCacheAtBudget = false;
   private engineRecoveryAnchor: EngineRecoveryAnchor | null = null;
   private remoteEvents: RemoteEventBuffer | null = null;
   private fullReplayCount = 0;
@@ -1588,6 +1606,10 @@ export class EgWalkerReplica {
 
   private fullReplay(): void {
     const graph = this.ensureEventGraph();
+    // A rebuild from scratch is exactly the cost a released cache was supposed
+    // to avoid. Widen the budget before this replay picks its retention so the
+    // interval can stay warm next time instead of thrashing.
+    this.growReplayCacheBudgetAfterThrash();
     this.captureEnginePeakBeforeSwap();
     if (graph.isExactLinearHistory()) {
       this.fullReplayLinearGraph(graph);
@@ -1670,9 +1692,8 @@ export class EgWalkerReplica {
         if (
           isLastSection &&
           section.endFrontier.size > 1 &&
-          canRetainReplayEngine(
+          this.canRetainReplayEngineWithinBudget(
             section.events.length,
-            this.documentBuffer,
             generated.stats,
           )
         ) {
@@ -1834,9 +1855,8 @@ export class EgWalkerReplica {
         if (
           isLastSection &&
           endVersion.size > 1 &&
-          canRetainReplayEngine(
+          this.canRetainReplayEngineWithinBudget(
             sectionEventCount,
-            this.documentBuffer,
             generated.stats,
           )
         ) {
@@ -2510,6 +2530,42 @@ export class EgWalkerReplica {
     };
   }
 
+  /**
+   * Widen the replay-cache budget when a refusal cost a full rebuild.
+   *
+   * A release is only worth its price when the state can be rebuilt cheaply.
+   * If the previous release happened at the byte budget and the very next thing
+   * the replica had to do was replay from scratch, the budget was too small for
+   * this history: nothing was saved and a whole-graph replay was paid for.
+   */
+  private growReplayCacheBudgetAfterThrash(): void {
+    if (!this.releasedCacheAtBudget) {
+      return;
+    }
+    this.releasedCacheAtBudget = false;
+    this.replayCacheBudgetBytes = Math.min(
+      this.replayCacheBudgetBytes * 2,
+      MAX_REPLAY_CACHE_BUDGET_BYTES,
+    );
+  }
+
+  /** Retention check against the adaptive budget, flagging a refusal. */
+  private canRetainReplayEngineWithinBudget(
+    eventCount: number,
+    stats: EngineStats,
+  ): boolean {
+    const retainable = canRetainReplayEngine(
+      eventCount,
+      this.documentBuffer,
+      stats,
+      this.replayCacheBudgetBytes,
+    );
+    if (!retainable) {
+      this.releasedCacheAtBudget = true;
+    }
+    return retainable;
+  }
+
   private refreshReplayCacheMetrics(): void {
     if (this.engine === null) {
       this.replayCacheEvents = 0;
@@ -2525,12 +2581,16 @@ export class EgWalkerReplica {
   }
 
   private evictReplayCacheIfNeeded(): void {
+    const overBudget = this.replayCacheBytes > this.replayCacheBudgetBytes;
     if (
-      this.replayCacheBytes <= MAX_REPLAY_CACHE_BYTES &&
+      !overBudget &&
       (this.replayCacheEvents <= REPLAY_CACHE_CRITICAL_RELEASE_EVENTS ||
         this.currentVersion.size > 1)
     ) {
       return;
+    }
+    if (overBudget && this.engine !== null) {
+      this.releasedCacheAtBudget = true;
     }
     this.captureEnginePeakBeforeSwap();
     this.engine = null;
@@ -2908,11 +2968,12 @@ const canRetainReplayEngine = (
   eventCount: number,
   document: PersistentUtf16Rope,
   stats: EngineStats,
+  budgetBytes: number,
 ): boolean =>
   document.length * 2 +
     stats.sequenceRecordCount * ESTIMATED_REPLAY_RECORD_BYTES +
     eventCount * ESTIMATED_DELETE_TARGET_BYTES <=
-  MAX_REPLAY_CACHE_BYTES;
+  budgetBytes;
 
 const mergeEngineStats = (
   aggregate: EngineStats | null,

--- a/packages/eg-walker/src/core/replica.ts
+++ b/packages/eg-walker/src/core/replica.ts
@@ -209,6 +209,8 @@ interface RemoteBatchSnapshot {
   readonly replayCacheCoverageChecks: number;
   readonly replayCacheEvents: number;
   readonly replayCacheBytes: number;
+  readonly replayCacheBudgetBytes: number;
+  readonly releasedCacheAtBudget: boolean;
   readonly engineRecoveryAnchor: EngineRecoveryAnchor | null;
 }
 
@@ -1058,6 +1060,7 @@ export class EgWalkerReplica {
     this.restoredDeleteTargets = null;
     this.incrementalApplyCount += events.length;
     this.lastReplaySource = REPLAY_SOURCE.INCREMENTAL;
+    this.clearSupersededReplayCacheRefusal();
     this.evictReplayCacheIfNeeded();
     this.maybeAdvanceCheckpoint();
     return true;
@@ -1391,6 +1394,8 @@ export class EgWalkerReplica {
       replayCacheCoverageChecks: this.replayCacheCoverageChecks,
       replayCacheEvents: this.replayCacheEvents,
       replayCacheBytes: this.replayCacheBytes,
+      replayCacheBudgetBytes: this.replayCacheBudgetBytes,
+      releasedCacheAtBudget: this.releasedCacheAtBudget,
       engineRecoveryAnchor: this.engineRecoveryAnchor,
     };
   }
@@ -1420,6 +1425,11 @@ export class EgWalkerReplica {
     this.replayCacheCoverageChecks = snapshot.replayCacheCoverageChecks;
     this.replayCacheEvents = snapshot.replayCacheEvents;
     this.replayCacheBytes = snapshot.replayCacheBytes;
+    // A batch that failed and rolled back never paid for its refusal, so the
+    // adaptive budget and the pending refusal both belong to the discarded
+    // attempt.
+    this.replayCacheBudgetBytes = snapshot.replayCacheBudgetBytes;
+    this.releasedCacheAtBudget = snapshot.releasedCacheAtBudget;
     this.engineRecoveryAnchor = snapshot.engineRecoveryAnchor;
 
     if (snapshot.engineStats === null) {
@@ -2404,6 +2414,7 @@ export class EgWalkerReplica {
       this.currentVersion = graph.getFrontier();
       this.incrementalApplyCount++;
       this.lastReplaySource = REPLAY_SOURCE.INCREMENTAL;
+      this.clearSupersededReplayCacheRefusal();
       this.maybeAdvanceCheckpoint();
       return toRemoteIntegrationEffect(operation === null ? [] : [operation]);
     }
@@ -2420,6 +2431,7 @@ export class EgWalkerReplica {
       this.incrementalApplyCount++;
       this.lastReplaySource = REPLAY_SOURCE.INCREMENTAL;
       this.replayCacheEvents++;
+      this.clearSupersededReplayCacheRefusal();
       this.refreshReplayCacheMetrics();
       this.evictReplayCacheIfNeeded();
       this.maybeAdvanceCheckpoint();
@@ -2538,6 +2550,18 @@ export class EgWalkerReplica {
    * the replica had to do was replay from scratch, the budget was too small for
    * this history: nothing was saved and a whole-graph replay was paid for.
    */
+  /**
+   * Drop a pending budget refusal once a cheaper path re-established state.
+   *
+   * A refusal only justifies growing the budget when the replica had to rebuild
+   * from scratch straight afterwards. An incremental apply or a partial replay
+   * from a checkpoint absorbed it instead, so it must not be carried forward
+   * and charged to some later, unrelated full replay.
+   */
+  private clearSupersededReplayCacheRefusal(): void {
+    this.releasedCacheAtBudget = false;
+  }
+
   private growReplayCacheBudgetAfterThrash(): void {
     if (!this.releasedCacheAtBudget) {
       return;
@@ -2603,6 +2627,7 @@ export class EgWalkerReplica {
 
   private partialReplayFromCheckpoint(checkpoint: CriticalCheckpoint): void {
     const graph = this.ensureEventGraph();
+    this.clearSupersededReplayCacheRefusal();
     this.captureEnginePeakBeforeSwap();
     const frontier = graph.getFrontier();
     const result = this.partialReplayer.replayFromCheckpoint(


### PR DESCRIPTION
## Summary

The full `@softmaple/bench` paper-bench run spends almost all of its time on the
two asynchronous traces. Profiling showed the cost is not the merge algorithm —
it is replay *planning*, entered over and over because two independent defects
make merge-heavy histories fall back to a whole-graph replay on nearly every
batch. On A1, 87% of apply time (28.2s of 32.5s) was spent inside the 15 batches
that triggered a full replay.

Both defects are fixed here. They are performance-only: every retained
checkpoint is still validated by `isStillCritical`, and the replay cache still
holds validated engine state.

## Defect 1 — the checkpoint ladder collapsed to a 31-event window

`CriticalCheckpointStore.append()` kept the newest `MAX_RETAINED_CHECKPOINTS`
cuts, but `maybeAdvance` records one checkpoint per incrementally applied event
(`replica.ts` calls it inside the per-event batch loop). The store therefore
filled with 32 *consecutive* cuts:

```
MISS graphEvents=184320 retained=32 oldestCut=180193 newestCut=180224 span=31
```

32 retained checkpoints spanning 31 events. The whole Section 3.5 critical
checkpoint mechanism had an effective look-back window of 31 events, so any
divergence reaching further back missed and forced a full replay — including a
whole-graph branch-preserving topological re-sort that also clones every event.
On A1 that was 15 cold re-sorts totalling 10.8s and 4,673,536 events sorted.

Fix: thin the ladder by eviction cost — the gap a removal opens relative to how
far that cut sits behind the head. Recent cuts stay dense, old gaps grow
geometrically, and a divergence at depth `d` still finds a checkpoint within a
small factor of `d`. The oldest and newest entries anchor the ladder and are
never evicted. Retention count is unchanged at 32.

## Defect 2 — the replay-cache budget thrashed

`canRetainReplayEngine()` and `evictReplayCacheIfNeeded()` both used a fixed
32 MiB. A concurrent interval spanning a whole document needs one sequence
record per code unit (estimated at 256 B each), so a 227k-code-unit history has
an intrinsic floor around 59 MB — the budget can never be satisfied:

```
evictions=48  meanEvictBytes=49.3 MiB  frontierSizeAtEvict={10:7, 8:7, 11:7, 7:5, 9:4, 6:4}
```

The engine was discarded 48 times *while the concurrent interval was still open*
(6–11 frontier tips), and the next batch immediately rebuilt the same interval.
No memory was saved; 47 full replays were paid for.

Fix: keep 32 MiB as the base budget, but grow it (doubling, capped at 8x) only
when a refusal at the budget was demonstrably followed by a full rebuild. The
existing guarantee is preserved — `replay-optimization.test.ts`'s "releases a
concurrent cache at the byte budget even before convergence" still passes,
because that case releases once and never replays again, so no growth triggers.

## Results

Full paper-bench, both lanes, all seven datasets, single run, 4096-event causal
batches, same machine:

| lane | before | after | speedup | peak RSS before | after |
| --- | --- | --- | --- | --- | --- |
| apply-S1 / S2 / S3 | 1.8 / 2.3 / 4.8s | 1.8 / 2.4 / 4.8s | ~1.00x | — | — |
| apply-C1 / C2 | 8.9 / 9.5s | 9.0 / 9.6s | ~1.00x | — | — |
| **apply-A1** | **33.9s** | **11.3s** | **3.01x** | 2.39G | **1.87G** |
| **apply-A2** | **227.2s** | **22.6s** | **10.06x** | 2.46G | **2.12G** |
| persistence-S1…C2 | 18.2–88.6s | 18.0–88.3s | 1.00–1.03x | — | — |
| **persistence-A1** | **61.9s** | **37.5s** | **1.65x** | 4.37G | 4.37G |
| **persistence-A2** | **244.2s** | **24.9s** | **9.80x** | 3.12G | **2.19G** |

Replay counters, A1 apply lane: `fullReplays` 15 → 0, `criticalCheckpointMisses`
15 → 0, cold branch-preserving topological sorts 15 → 0. A2: `fullReplays`
47 → 4, replay-cache evictions 48 → 4.

Total full-bench wall clock: 788.8s → 316.2s (2.5x). S1/S2/S3/C1/C2 are
unchanged within run-to-run noise. `peakSequenceRecordCount` rises on A1
(70,640 → 136,228) because partial replays now start from an older checkpoint,
but measured peak RSS still drops 22%.

## Not addressed here

The A2 lanes still exit non-zero on their `endContent` assertion. That is not an
engine bug: `@softmaple/eg-walker` reproduces `datasets/A2.json` byte-identically
with the paper's own `diamond-types-crdt` reference implementation
(`3a4da13d…`), and reproduces the paper's expected text exactly
(`679d80c2…`) when the trace keeps its real agent identities. `dt export-trace`
splits 45 agents across 76 extra numeric slots on A2, which reverses 422
concurrent tie-breaks, so `A2.json`'s `endContent` is not reachable from its own
data. That is a separate `@softmaple/bench` expectation fix.

## Test plan

- `npx tsc --noEmit` in `packages/eg-walker` — clean
- `npx vitest run` in `packages/eg-walker` — 743 tests / 92 files pass
- Full paper-bench re-run, both lanes, all seven datasets — table above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaushsStVSUfV7F7BtsCza


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved checkpoint retention to preserve more useful history during overflow, supporting smoother navigation and replay.
  - Replay caching now adapts to workload demands while respecting an upper memory limit, helping reduce unnecessary full replays.
  - Improved handling of memory pressure during replay to balance responsiveness with resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->