### PR TITLE
feat(apps/web): redesign the writing studio with mobile Sheets and keyboard search

### DIFF
--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -12,13 +12,13 @@ export default function DashboardLayout({
   return (
     <div className="min-h-dvh bg-background">
       <header className="border-b bg-background/85 backdrop-blur">
-        <div className="mx-auto flex h-14 max-w-7xl items-center justify-between gap-4 px-4 sm:px-6">
+        <div className="mx-auto flex h-20 max-w-7xl items-center justify-between gap-4 px-5 sm:px-8">
           <Link
             aria-label="Softmaple dashboard"
             className="inline-flex min-w-0 items-center rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
             href="/dashboard"
           >
-            <SoftmapleWordmark className="text-lg" />
+            <SoftmapleWordmark className="text-2xl" />
           </Link>
           <div className="flex shrink-0 items-center gap-2">
             <SettingsDropdown />
@@ -31,7 +31,7 @@ export default function DashboardLayout({
                 await logout();
               }}
             >
-              Logout
+              Sign out
             </Button>
           </div>
         </div>

--- a/apps/web/app/design.css
+++ b/apps/web/app/design.css
@@ -1,68 +1,62 @@
 :root {
-  --background: #f5f5f2;
-  --foreground: #17171a;
+  --background: #f7f8fc;
+  --foreground: #20263f;
   --card: #ffffff;
-  --card-foreground: #17171a;
+  --card-foreground: #20263f;
   --popover: #ffffff;
-  --popover-foreground: #17171a;
-  --primary: #c9184a;
+  --popover-foreground: #20263f;
+  --primary: #4859b8;
   --primary-foreground: #ffffff;
-  --secondary: #ecece8;
-  --secondary-foreground: #17171a;
-  --muted: #ecece8;
-  --muted-foreground: #66666f;
-  --accent: #ecece8;
-  --accent-foreground: #17171a;
+  --secondary: #edeff9;
+  --secondary-foreground: #20263f;
+  --muted: #edeff9;
+  --muted-foreground: #656d85;
+  --accent: #edeff9;
+  --accent-foreground: #20263f;
   --destructive: #b42335;
   --destructive-foreground: #ffffff;
-  --border: #d8d8d2;
-  --input: #d8d8d2;
-  --ring: #c9184a;
+  --border: #dce0ed;
+  --input: #dce0ed;
+  --ring: #4859b8;
   --sidebar: #ffffff;
-  --sidebar-foreground: #17171a;
-  --sidebar-primary: #c9184a;
+  --sidebar-foreground: #20263f;
+  --sidebar-primary: #4859b8;
   --sidebar-primary-foreground: #ffffff;
-  --sidebar-accent: #ecece8;
-  --sidebar-accent-foreground: #17171a;
-  --sidebar-border: #d8d8d2;
-  --sidebar-ring: #c9184a;
-  --radius: 0.3rem;
-  --ambient-rose: rgb(201 24 74 / 10%);
-  --ambient-teal: rgb(14 116 110 / 8%);
-  --ambient-orange: rgb(234 88 12 / 7%);
+  --sidebar-accent: #edeff9;
+  --sidebar-accent-foreground: #20263f;
+  --sidebar-border: #dce0ed;
+  --sidebar-ring: #4859b8;
+  --radius: 0.75rem;
 }
 
 .dark {
-  --background: #050505;
-  --foreground: #ededed;
-  --card: #121216;
-  --card-foreground: #ededed;
-  --popover: #121216;
-  --popover-foreground: #ededed;
-  --primary: #f43f75;
-  --primary-foreground: #ffffff;
-  --secondary: #1a1a20;
-  --secondary-foreground: #ededed;
-  --muted: #1a1a20;
-  --muted-foreground: #a1a1aa;
-  --accent: #1a1a20;
-  --accent-foreground: #ededed;
+  --background: #141827;
+  --foreground: #eef0fa;
+  --card: #1c2235;
+  --card-foreground: #eef0fa;
+  --popover: #1c2235;
+  --popover-foreground: #eef0fa;
+  --primary: #acb8ff;
+  --primary-foreground: #141827;
+  --secondary: #252d45;
+  --secondary-foreground: #eef0fa;
+  --muted: #252d45;
+  --muted-foreground: #aab3cc;
+  --accent: #252d45;
+  --accent-foreground: #eef0fa;
   --destructive: #fb7185;
-  --destructive-foreground: #050505;
-  --border: #2a2a31;
-  --input: #2a2a31;
-  --ring: #f43f75;
-  --sidebar: #121216;
-  --sidebar-foreground: #ededed;
-  --sidebar-primary: #f43f75;
-  --sidebar-primary-foreground: #ffffff;
-  --sidebar-accent: #1a1a20;
-  --sidebar-accent-foreground: #ededed;
-  --sidebar-border: #2a2a31;
-  --sidebar-ring: #f43f75;
-  --ambient-rose: rgb(244 63 117 / 13%);
-  --ambient-teal: rgb(45 212 191 / 8%);
-  --ambient-orange: rgb(251 146 60 / 7%);
+  --destructive-foreground: #141827;
+  --border: #353e59;
+  --input: #353e59;
+  --ring: #acb8ff;
+  --sidebar: #1c2235;
+  --sidebar-foreground: #eef0fa;
+  --sidebar-primary: #acb8ff;
+  --sidebar-primary-foreground: #141827;
+  --sidebar-accent: #252d45;
+  --sidebar-accent-foreground: #eef0fa;
+  --sidebar-border: #353e59;
+  --sidebar-ring: #acb8ff;
 }
 
 @theme inline {
@@ -80,11 +74,6 @@
     min-width: 320px;
     min-height: 100dvh;
     overflow-x: clip;
-    background-image:
-      radial-gradient(circle at 8% 6%, var(--ambient-rose), transparent 24rem),
-      radial-gradient(circle at 91% 18%, var(--ambient-teal), transparent 23rem),
-      radial-gradient(circle at 76% 92%, var(--ambient-orange), transparent 25rem);
-    background-attachment: fixed;
   }
 
   ::selection {
@@ -93,6 +82,38 @@
 }
 
 @layer components {
+  .manuscript-stage {
+    position: relative;
+    padding: 2rem 1.2rem 2.5rem;
+    border-radius: 2rem;
+    background: var(--secondary);
+  }
+
+  .manuscript-sheet {
+    position: relative;
+    border: 1px solid var(--border);
+    border-radius: 0.9rem;
+    background: var(--card);
+    box-shadow: 0 22px 45px -25px color-mix(in srgb, var(--primary) 35%, transparent);
+    transform: rotate(-2deg);
+  }
+
+  .manuscript-note {
+    position: absolute;
+    right: 1.5rem;
+    bottom: 1.25rem;
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    border: 1px solid var(--border);
+    border-radius: 0.7rem;
+    background: var(--card);
+    padding: 0.8rem 1rem;
+    color: var(--primary);
+    font-size: 0.75rem;
+    box-shadow: 0 4px 16px color-mix(in srgb, var(--foreground) 6%, transparent);
+  }
+
   .markdown-preview {
     color: var(--foreground);
     line-height: 1.75;

--- a/apps/web/app/workspace/[workspaceSlug]/page.tsx
+++ b/apps/web/app/workspace/[workspaceSlug]/page.tsx
@@ -86,7 +86,7 @@ export default async function WorkspacePage({ params }: Props) {
 
   return (
     <div className="min-w-0 flex-1 overflow-y-auto">
-      <header className="border-b px-4 py-6 sm:px-6 lg:px-8">
+      <header className="border-b bg-card/50 px-4 py-8 sm:px-6 lg:px-8">
         <div className="mx-auto flex max-w-6xl flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
           <div className="min-w-0">
             <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-primary">
@@ -105,14 +105,14 @@ export default async function WorkspacePage({ params }: Props) {
                 href={`/workspace/${workspaceSlug}/settings`}
                 prefetch={false}
               >
-                <Settings2 className="mr-2 h-4 w-4" />
+                <Settings2 data-icon="inline-start" />
                 Settings
               </Link>
             </Button>
             {canEdit ? (
               <Button asChild>
                 <Link href={`/workspace/${workspaceSlug}/doc/new`}>
-                  <Plus className="mr-2 h-4 w-4" />
+                  <Plus data-icon="inline-start" />
                   New document
                 </Link>
               </Button>
@@ -132,12 +132,11 @@ export default async function WorkspacePage({ params }: Props) {
             </div>
           </div>
           {documents.length === 0 ? (
-            <div className="rounded-sm border border-dashed p-10 text-center">
+            <div className="rounded-xl border border-dashed p-10 text-center">
               <FileText className="mx-auto h-8 w-8 text-muted-foreground" />
               <h3 className="mt-4 font-medium">No documents yet</h3>
               <p className="mt-1 text-sm text-muted-foreground">
-                Create one and the first character will be saved to
-                collaborative history.
+                Give your next idea a page of its own.
               </p>
               {canEdit ? (
                 <Button asChild className="mt-5" size="sm">
@@ -148,14 +147,14 @@ export default async function WorkspacePage({ params }: Props) {
               ) : null}
             </div>
           ) : (
-            <div className="divide-y rounded-sm border bg-card">
+            <div className="divide-y rounded-xl border bg-card">
               {documents.map((document) => (
                 <Link
                   className="flex min-w-0 items-center gap-4 p-4 transition-colors hover:bg-accent"
                   href={`/workspace/${workspaceSlug}/doc/${document.slug}`}
                   key={document.id}
                 >
-                  <div className="grid h-9 w-9 shrink-0 place-items-center rounded-sm border bg-background text-primary">
+                  <div className="grid h-9 w-9 shrink-0 place-items-center rounded-xl border bg-background text-primary">
                     <FileText className="h-4 w-4" />
                   </div>
                   <div className="min-w-0 flex-1">
@@ -185,10 +184,10 @@ export default async function WorkspacePage({ params }: Props) {
             </div>
             <Users className="h-4 w-4 text-muted-foreground" />
           </div>
-          <div className="space-y-1">
+          <div className="flex flex-col gap-1">
             {members.slice(0, 8).map((member) => (
               <div
-                className="flex items-center gap-3 rounded-sm px-2 py-2"
+                className="flex items-center gap-3 rounded-xl px-2 py-2"
                 key={member.member_id}
               >
                 <Avatar className="h-8 w-8">

--- a/apps/web/components/landing.tsx
+++ b/apps/web/components/landing.tsx
@@ -1,222 +1,215 @@
 import Link from "next/link";
 import {
+  ArrowRight,
   ArrowUpRight,
   Check,
-  Circle,
   FileCode2,
-  Github,
-  Radio,
+  FileText,
+  Link2,
   Users,
+  PenLine,
 } from "lucide-react";
 import { Button } from "@softmaple/ui/components/button";
-import { ModeToggle } from "@/components/mode-toggle";
+import { Badge } from "@softmaple/ui/components/badge";
+import { Separator } from "@softmaple/ui/components/separator";
 import { SITE_CONFIG } from "@softmaple/config";
+import { SiteHeader } from "@/components/site-header";
+import { SoftmapleWordmark } from "@/components/BrandMark";
 
-const FEATURES = [
+const features = [
   {
-    index: "01",
-    title: "Durable collaboration",
-    body: "Concurrent rich-text edits are persisted as event batches, acknowledged, repaired after reconnect, and replayed into the same document state.",
+    icon: Users,
+    title: "Good ideas have company.",
+    body: "Write together in the same document. See who’s here and pick up where you left off, even after reconnecting.",
+    label: "Made for collaboration",
   },
   {
-    index: "02",
-    title: "Presence with real identity",
-    body: "Workspace members see who is here, across tabs, with profile-backed names and ephemeral cursor state that never pollutes the database.",
+    icon: FileCode2,
+    title: "Your words. More possibilities.",
+    body: "Move between rich text, Preview, Markdown, and LaTeX. Keep your attention on the idea while the format falls into place.",
+    label: "One document, four views",
   },
   {
-    index: "03",
-    title: "One source, four views",
-    body: "Edit visually, then inspect live Preview, Markdown, or a complete LaTeX document—all derived from the current collaborative editor state.",
+    icon: Link2,
+    title: "Share when you’re ready.",
+    body: "Give your work a read-only public link. Keep editing in your workspace, and turn off the link whenever you need to.",
+    label: "Sharing on your terms",
   },
-  {
-    index: "04",
-    title: "Controlled public sharing",
-    body: "Owners can issue a stable, unlisted read-only link and revoke it without exposing workspace membership or export controls.",
-  },
-] as const;
+];
 
 export default function LandingPage() {
   return (
     <div className="min-h-dvh bg-background text-foreground">
-      <header className="border-b bg-background/80 backdrop-blur">
-        <div className="mx-auto flex h-14 max-w-7xl items-center gap-5 px-4 sm:px-6">
-          <Link
-            className="font-display text-lg font-bold tracking-tight"
-            href="/"
-          >
-            softmaple<span className="text-primary">.</span>
-          </Link>
-          <nav className="ml-auto hidden items-center gap-5 font-mono text-[11px] sm:flex">
-            <a href={SITE_CONFIG.PLAYGROUND}>Playground</a>
-            <a href={SITE_CONFIG.DOCS}>Docs</a>
-            <a href={SITE_CONFIG.GITHUB_REPO}>GitHub</a>
-          </nav>
-          <ModeToggle />
-          <Button
-            asChild
-            className="hidden sm:inline-flex"
-            size="sm"
-            variant="ghost"
-          >
-            <Link href="/login">Sign in</Link>
-          </Button>
-          <Button asChild size="sm">
-            <Link href="/signup">Start writing</Link>
-          </Button>
-        </div>
-      </header>
-
-      <main>
-        <section className="mx-auto grid max-w-7xl border-x lg:grid-cols-[1.08fr_0.92fr]">
-          <div className="relative min-h-[34rem] border-b p-6 sm:p-10 lg:border-b-0 lg:border-r lg:p-16">
-            <div className="absolute left-0 top-10 h-px w-10 bg-primary sm:w-16" />
-            <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-primary">
-              Collaborative document infrastructure
-            </p>
-            <h1 className="mt-12 max-w-3xl font-display text-[clamp(3rem,8vw,6.6rem)] font-semibold leading-[0.9] tracking-[-0.055em]">
-              Ideas move.
+      <a
+        className="sr-only focus:not-sr-only focus:absolute focus:bg-card focus:p-4"
+        href="#main"
+      >
+        Skip to content
+      </a>
+      <SiteHeader />
+      <main id="main">
+        <section className="mx-auto grid max-w-7xl items-center gap-12 px-5 py-16 sm:px-8 sm:py-20 lg:grid-cols-[0.95fr_1.05fr] lg:gap-10 lg:py-24">
+          <div>
+            <Badge variant="secondary">
+              <PenLine data-icon="inline-start" /> A shared space for your words
+            </Badge>
+            <h1 className="mt-7 font-display text-[clamp(3.25rem,6.6vw,6rem)] font-semibold leading-[1.02] tracking-[-0.065em]">
+              A little space.
               <br />
-              The record
-              <br />
-              holds.
+              For <span className="text-primary">big ideas.</span>
             </h1>
-            <p className="mt-10 max-w-xl text-base leading-7 text-muted-foreground sm:ml-20">
-              Softmaple is a high-density workspace for durable collaborative
-              writing, live presence, Markdown and LaTeX output, and deliberate
-              public sharing.
+            <p className="mt-7 max-w-md text-lg leading-8 text-muted-foreground">
+              From the first rough note to the final paper. Write, shape, and
+              share your thinking, together.
             </p>
-            <div className="mt-9 flex flex-wrap gap-3 sm:ml-20">
+            <div className="mt-9 flex flex-wrap gap-3">
               <Button asChild size="lg">
                 <Link href="/signup">
-                  Create a workspace <ArrowUpRight className="size-4" />
+                  Start writing <ArrowRight data-icon="inline-end" />
                 </Link>
               </Button>
               <Button asChild size="lg" variant="outline">
-                <a href={SITE_CONFIG.PLAYGROUND}>Open playground</a>
+                <a href={SITE_CONFIG.PLAYGROUND}>
+                  Explore the editor <ArrowUpRight data-icon="inline-end" />
+                </a>
               </Button>
             </div>
+            <p className="mt-5 text-sm text-muted-foreground">
+              Rich text. Markdown. LaTeX. Room to think.
+            </p>
           </div>
-
-          <div className="flex min-h-[34rem] flex-col justify-center bg-card/70 p-4 sm:p-8 lg:p-10">
-            <div className="border bg-background shadow-[0_24px_80px_-48px_rgba(201,24,74,0.7)]">
-              <div className="flex items-center gap-2 border-b px-3 py-2 font-mono text-[10px] text-muted-foreground">
-                <Circle className="size-2.5 fill-primary text-primary" />
-                field-notes / carbon-cycle
-                <span className="ml-auto flex items-center gap-1 text-teal-600 dark:text-teal-400">
-                  <Check className="size-3" /> Saved
+          <div
+            className="manuscript-stage"
+            aria-label="Example of a shared Softmaple document"
+          >
+            <div className="manuscript-sheet">
+              <div className="flex items-center gap-2 border-b px-5 py-4 text-xs text-muted-foreground">
+                <FileText className="size-4 text-primary" />
+                <span className="truncate">
+                  Field notes / A slower kind of progress
                 </span>
+                <Check className="ml-auto size-4 shrink-0 text-primary" />
+                <span className="hidden sm:inline">Saved</span>
               </div>
-              <div className="grid grid-cols-[2.6rem_1fr]">
-                <div className="border-r py-6 text-center font-mono text-[10px] leading-7 text-muted-foreground">
-                  01
+              <div className="px-6 py-9 sm:px-10 sm:py-12">
+                <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+                  Field notes · Working draft
+                </p>
+                <h2 className="mt-5 font-display text-3xl font-semibold leading-tight tracking-tight sm:text-4xl">
+                  A slower kind
                   <br />
-                  02
+                  of progress
+                </h2>
+                <p className="mt-6 text-sm leading-7 text-muted-foreground">
+                  What if the most useful thing we could make was a little more
+                  room to think?
+                </p>
+                <p className="mt-4 text-sm leading-7">
+                  A place for unfinished sentences.
                   <br />
-                  03
+                  For questions worth sitting with.
                   <br />
-                  04
-                  <br />
-                  05
-                  <br />
-                  06
-                </div>
-                <div className="relative px-5 py-6 sm:px-7">
-                  <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-primary">
-                    Observation / 09:42
-                  </p>
-                  <h2 className="mt-4 font-display text-2xl font-semibold">
-                    A shared record of change
-                  </h2>
-                  <p className="mt-4 max-w-md text-sm leading-7 text-muted-foreground">
-                    Each insertion becomes a durable event. When Lina
-                    reconnects, repair resumes after the last acknowledged
-                    cursor—without overwriting Marco’s concurrent paragraph.
-                  </p>
-                  <blockquote className="mt-5 border-l-2 border-primary pl-4 text-sm italic">
-                    The document converges; the writers keep their context.
-                  </blockquote>
-                  <span className="absolute right-12 top-32 h-5 border-l-2 border-teal-500" />
-                  <span className="absolute right-3 top-[8.1rem] bg-teal-600 px-1.5 py-0.5 font-mono text-[9px] text-white">
-                    Lina
+                  <span className="bg-accent text-accent-foreground">
+                    For ideas that get better together.
                   </span>
+                </p>
+                <Separator className="my-7" />
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <span className="grid size-7 place-items-center rounded-full bg-secondary text-primary">
+                    L
+                  </span>
+                  <span>Lina is writing…</span>
+                  <PenLine className="ml-auto size-4 text-primary" />
                 </div>
               </div>
-              <div className="flex flex-wrap items-center gap-3 border-t px-3 py-2 font-mono text-[10px] text-muted-foreground">
-                <span className="flex items-center gap-1.5">
-                  <Radio className="size-3 text-primary" /> 3 active
-                </span>
-                <span className="flex items-center gap-1.5">
-                  <FileCode2 className="size-3" /> Markdown / LaTeX
-                </span>
-                <span className="ml-auto flex items-center gap-1.5">
-                  <Users className="size-3" /> Owner · 2 editors
-                </span>
+              <div className="flex flex-wrap items-center gap-4 border-t px-5 py-3 text-[11px] text-muted-foreground">
+                <span className="font-medium text-primary">Rich text</span>
+                <span>Preview</span>
+                <span>Markdown</span>
+                <span>LaTeX</span>
               </div>
+            </div>
+            <div className="manuscript-note">
+              <Users className="size-4" />
+              <span>A shared thought starts here.</span>
             </div>
           </div>
         </section>
-
-        <section className="mx-auto max-w-7xl border-x border-t">
-          <div className="grid lg:grid-cols-[18rem_1fr]">
-            <div className="border-b p-6 lg:border-b-0 lg:border-r lg:p-9">
-              <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-primary">
-                Product surface
-              </p>
-              <h2 className="mt-4 font-display text-3xl font-semibold">
-                Focused on the work that exists today.
-              </h2>
-            </div>
-            <div className="grid sm:grid-cols-2">
-              {FEATURES.map((feature) => (
-                <article
-                  className="min-h-56 border-b p-6 odd:sm:border-r last:border-b-0 sm:[&:nth-last-child(2)]:border-b-0 sm:p-8"
-                  key={feature.index}
-                >
-                  <span className="font-mono text-[10px] text-primary">
-                    {feature.index}
-                  </span>
-                  <h3 className="mt-8 font-display text-xl font-semibold">
-                    {feature.title}
-                  </h3>
-                  <p className="mt-3 text-sm leading-6 text-muted-foreground">
-                    {feature.body}
-                  </p>
-                </article>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        <section className="mx-auto max-w-7xl border-x border-t px-6 py-16 sm:px-10 sm:py-24">
-          <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-primary">
-            Ready when the document is
-          </p>
-          <div className="mt-5 flex flex-col items-start justify-between gap-8 lg:flex-row lg:items-end">
-            <h2 className="max-w-3xl font-display text-4xl font-semibold leading-none sm:text-6xl">
-              Start a workspace. Write the first durable line.
+        <section
+          className="mx-auto max-w-7xl px-5 pb-20 sm:px-8 lg:pb-28"
+          aria-labelledby="features-heading"
+        >
+          <div className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <h2
+              id="features-heading"
+              className="max-w-lg font-display text-3xl font-semibold tracking-tight sm:text-4xl"
+            >
+              Less between you
+              <br />
+              and the next sentence.
             </h2>
-            <Button asChild size="lg">
-              <Link href="/signup">Create your account</Link>
-            </Button>
+            <p className="max-w-xs text-sm leading-6 text-muted-foreground">
+              A focused toolkit for the way ideas actually take shape.
+            </p>
           </div>
+          <div className="grid gap-5 md:grid-cols-3">
+            {features.map(({ icon: Icon, ...feature }) => (
+              <article
+                className="rounded-2xl border bg-card p-7"
+                key={feature.title}
+              >
+                <div className="mb-8 flex items-center gap-3">
+                  <span className="grid size-10 place-items-center rounded-xl bg-secondary text-primary">
+                    <Icon className="size-5" />
+                  </span>
+                  <p className="text-xs text-muted-foreground">
+                    {feature.label}
+                  </p>
+                </div>
+                <h3 className="font-display text-xl font-semibold tracking-tight">
+                  {feature.title}
+                </h3>
+                <p className="mt-3 text-sm leading-7 text-muted-foreground">
+                  {feature.body}
+                </p>
+              </article>
+            ))}
+          </div>
+        </section>
+        <section className="bg-secondary px-5 py-16 text-center sm:px-8 sm:py-20">
+          <p className="font-mono text-xs text-muted-foreground">
+            THE NEXT PAGE IS YOURS
+          </p>
+          <h2 className="mt-5 font-display text-4xl font-semibold tracking-tight sm:text-5xl">
+            Make room for a new idea.
+          </h2>
+          <p className="mt-4 text-muted-foreground">
+            Open a workspace. Invite your people. Find your words.
+          </p>
+          <Button asChild className="mt-7" size="lg">
+            <Link href="/signup">
+              Create your workspace <ArrowRight data-icon="inline-end" />
+            </Link>
+          </Button>
         </section>
       </main>
-
-      <footer className="border-t">
-        <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-6 font-mono text-[10px] text-muted-foreground sm:flex-row sm:items-center sm:px-6">
-          <span>© {new Date().getFullYear()} Softmaple</span>
-          <div className="flex flex-wrap gap-5 sm:ml-auto">
-            <a href={SITE_CONFIG.DOCS}>Docs</a>
-            <a
-              href={SITE_CONFIG.GITHUB_REPO}
-              className="flex items-center gap-1"
-            >
-              <Github className="size-3" /> GitHub
-            </a>
-            <a href={SITE_CONFIG.TWITTER}>X</a>
-            <a href={`mailto:${SITE_CONFIG.CONTACT_EMAIL}`}>Email</a>
-          </div>
-        </div>
+      <footer className="mx-auto flex max-w-7xl flex-col gap-6 px-5 py-9 sm:flex-row sm:items-center sm:px-8">
+        <Link href="/" aria-label="Softmaple home">
+          <SoftmapleWordmark className="text-xl" />
+        </Link>
+        <span className="text-xs text-muted-foreground">
+          © {new Date().getFullYear()} Softmaple
+        </span>
+        <nav
+          aria-label="Footer"
+          className="flex flex-wrap gap-6 text-sm text-muted-foreground sm:ml-auto"
+        >
+          <a href={SITE_CONFIG.DOCS}>Docs</a>
+          <a href={SITE_CONFIG.GITHUB_REPO}>GitHub</a>
+          <a href={`mailto:${SITE_CONFIG.CONTACT_EMAIL}`}>
+            Say hello <span aria-hidden="true">↗</span>
+          </a>
+        </nav>
       </footer>
     </div>
   );

--- a/apps/web/components/search-field.test.tsx
+++ b/apps/web/components/search-field.test.tsx
@@ -55,6 +55,21 @@ describe("search keyboard shortcuts", () => {
     expect(container.querySelector("kbd")?.textContent).toBe("/");
   });
 
+  it("keeps its query when Escape ends an IME composition", () => {
+    const search = container.querySelector("input")!;
+    act(() =>
+      search.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Escape",
+          isComposing: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      ),
+    );
+    expect(search.value).toBe("notes");
+  });
+
   it("does not steal slash from a document editor or form field", () => {
     for (const tag of ["input", "textarea", "div"]) {
       const editor = document.createElement(tag);

--- a/apps/web/components/search-field.test.tsx
+++ b/apps/web/components/search-field.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { act, createElement, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SearchField } from "./search-field";
+
+function Harness() {
+  const [query, setQuery] = useState("notes");
+  return (
+    <SearchField label="Search documents" value={query} onChange={setQuery} />
+  );
+}
+
+describe("search keyboard shortcuts", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+    act(() => root.render(createElement(Harness)));
+    vi.spyOn(HTMLElement.prototype, "getClientRects").mockReturnValue(
+      Object.assign([new DOMRect()], { item: () => new DOMRect() }),
+    );
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("focuses search with slash and clears its query with Escape", () => {
+    const search = container.querySelector("input")!;
+    act(() =>
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "/",
+          bubbles: true,
+          cancelable: true,
+        }),
+      ),
+    );
+    expect(document.activeElement).toBe(search);
+    act(() =>
+      search.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Escape",
+          bubbles: true,
+          cancelable: true,
+        }),
+      ),
+    );
+    expect(search.value).toBe("");
+    expect(document.activeElement).toBe(search);
+    expect(container.querySelector("kbd")?.textContent).toBe("/");
+  });
+
+  it("does not steal slash from a document editor or form field", () => {
+    for (const tag of ["input", "textarea", "div"]) {
+      const editor = document.createElement(tag);
+      if (tag === "div") editor.setAttribute("contenteditable", "true");
+      container.append(editor);
+      editor.focus();
+      const key = new KeyboardEvent("keydown", {
+        key: "/",
+        bubbles: true,
+        cancelable: true,
+      });
+      act(() => editor.dispatchEvent(key));
+      expect(document.activeElement).toBe(editor);
+      expect(key.defaultPrevented).toBe(false);
+      editor.remove();
+    }
+  });
+
+  it("ignores hidden sidebars, modal-hidden content, and modified keys", () => {
+    const search = container.querySelector("input")!;
+    for (const options of [
+      { ctrlKey: true },
+      { metaKey: true },
+      { altKey: true },
+      { isComposing: true },
+    ]) {
+      act(() =>
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "/", ...options }),
+        ),
+      );
+      expect(document.activeElement).not.toBe(search);
+    }
+    container.setAttribute("aria-hidden", "true");
+    act(() =>
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "/" })),
+    );
+    expect(document.activeElement).not.toBe(search);
+    container.removeAttribute("aria-hidden");
+    vi.mocked(HTMLElement.prototype.getClientRects).mockReturnValue(
+      Object.assign([], { item: () => null }),
+    );
+    act(() =>
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "/" })),
+    );
+    expect(document.activeElement).not.toBe(search);
+  });
+});

--- a/apps/web/components/search-field.tsx
+++ b/apps/web/components/search-field.tsx
@@ -67,7 +67,13 @@ export function SearchField({
         value={value}
         onChange={(event) => onChange(event.target.value)}
         onKeyDown={(event) => {
-          if (event.key === "Escape" && value) {
+          // Escape during IME composition commits/cancels the candidate
+          // window; it must not clear the query.
+          if (
+            event.key === "Escape" &&
+            !event.nativeEvent.isComposing &&
+            value
+          ) {
             event.preventDefault();
             event.stopPropagation();
             onChange("");

--- a/apps/web/components/search-field.tsx
+++ b/apps/web/components/search-field.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Search } from "lucide-react";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@softmaple/ui/components/input-group";
+import { Kbd } from "@softmaple/ui/components/kbd";
+
+export function SearchField({
+  label,
+  value,
+  onChange,
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const focusSearch = (event: KeyboardEvent) => {
+      if (
+        event.key !== "/" ||
+        event.defaultPrevented ||
+        event.isComposing ||
+        event.repeat ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.altKey
+      )
+        return;
+      const target = event.target;
+      if (
+        target instanceof Element &&
+        target.closest(
+          "input, textarea, select, [contenteditable]:not([contenteditable='false']), [role='textbox']",
+        )
+      )
+        return;
+      const input = inputRef.current;
+      // Both workspace sidebars are mounted; only the visible, non-modal-hidden
+      // search field can own the shortcut.
+      if (
+        !input ||
+        input.getClientRects().length === 0 ||
+        input.closest('[inert], [aria-hidden="true"]')
+      )
+        return;
+      event.preventDefault();
+      input.focus();
+    };
+    document.addEventListener("keydown", focusSearch);
+    return () => document.removeEventListener("keydown", focusSearch);
+  }, []);
+
+  return (
+    <InputGroup>
+      <InputGroupInput
+        ref={inputRef}
+        aria-label={label}
+        aria-keyshortcuts="/"
+        placeholder={label}
+        type="search"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Escape" && value) {
+            event.preventDefault();
+            event.stopPropagation();
+            onChange("");
+          }
+        }}
+      />
+      <InputGroupAddon>
+        <Search />
+      </InputGroupAddon>
+      <InputGroupAddon align="inline-end">
+        <Kbd aria-hidden="true">/</Kbd>
+      </InputGroupAddon>
+    </InputGroup>
+  );
+}

--- a/apps/web/components/site-header.tsx
+++ b/apps/web/components/site-header.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ArrowUpRight, Menu } from "lucide-react";
+import { Button } from "@softmaple/ui/components/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@softmaple/ui/components/sheet";
+import { SITE_CONFIG } from "@softmaple/config";
+import { SoftmapleWordmark } from "@/components/BrandMark";
+import { ModeToggle } from "@/components/mode-toggle";
+
+const links = [
+  { label: "Playground", href: SITE_CONFIG.PLAYGROUND },
+  { label: "Docs", href: SITE_CONFIG.DOCS },
+  { label: "GitHub", href: SITE_CONFIG.GITHUB_REPO },
+];
+
+export function SiteHeader() {
+  const [open, setOpen] = useState(false);
+  useEffect(() => {
+    const desktop = window.matchMedia("(min-width: 768px)");
+    const closeOnDesktop = () => {
+      if (desktop.matches) setOpen(false);
+    };
+    desktop.addEventListener("change", closeOnDesktop);
+    return () => desktop.removeEventListener("change", closeOnDesktop);
+  }, []);
+
+  return (
+    <header className="border-b border-border/60 bg-background">
+      <div className="mx-auto flex h-20 max-w-7xl items-center gap-3 px-5 sm:px-8">
+        <Link href="/" aria-label="Softmaple home">
+          <SoftmapleWordmark className="text-2xl" />
+        </Link>
+        <nav
+          aria-label="Main navigation"
+          className="ml-12 hidden items-center gap-7 text-sm text-muted-foreground md:flex"
+        >
+          {links.map((link) => (
+            <a
+              className="transition-colors hover:text-foreground"
+              href={link.href}
+              key={link.label}
+            >
+              {link.label}
+            </a>
+          ))}
+        </nav>
+        <div className="ml-auto flex items-center gap-2">
+          <ModeToggle />
+          <Button asChild className="hidden md:inline-flex" variant="ghost">
+            <Link href="/login">Sign in</Link>
+          </Button>
+          <Button asChild className="hidden md:inline-flex">
+            <Link href="/signup">
+              Start writing <ArrowUpRight data-icon="inline-end" />
+            </Link>
+          </Button>
+          <Sheet open={open} onOpenChange={setOpen}>
+            <SheetTrigger asChild>
+              <Button
+                className="md:hidden"
+                size="icon"
+                variant="outline"
+                aria-label="Open navigation"
+              >
+                <Menu />
+              </Button>
+            </SheetTrigger>
+            <SheetContent className="w-[min(22rem,90vw)] overflow-y-auto">
+              <SheetHeader>
+                <SheetTitle>
+                  <SoftmapleWordmark className="text-xl" />
+                </SheetTitle>
+                <SheetDescription>Your next idea starts here.</SheetDescription>
+              </SheetHeader>
+              <nav
+                aria-label="Mobile navigation"
+                className="flex flex-col gap-2 px-4"
+              >
+                {links.map((link) => (
+                  <Button
+                    asChild
+                    variant="ghost"
+                    className="justify-start"
+                    key={link.label}
+                  >
+                    <a href={link.href} onClick={() => setOpen(false)}>
+                      {link.label}
+                      <ArrowUpRight data-icon="inline-end" />
+                    </a>
+                  </Button>
+                ))}
+              </nav>
+              <div className="mt-auto flex flex-col gap-3 p-4">
+                <Button asChild variant="outline">
+                  <Link href="/login" onClick={() => setOpen(false)}>
+                    Sign in
+                  </Link>
+                </Button>
+                <Button asChild>
+                  <Link href="/signup" onClick={() => setOpen(false)}>
+                    Start writing
+                  </Link>
+                </Button>
+              </div>
+            </SheetContent>
+          </Sheet>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/apps/web/e2e/public.spec.ts
+++ b/apps/web/e2e/public.spec.ts
@@ -7,7 +7,7 @@ test.describe("public product surface", () => {
     await page.goto("/");
     await expect(page).toHaveTitle(/Softmaple/);
     await expect(page.getByRole("heading", { level: 1 })).toContainText(
-      "Ideas move",
+      "A little space",
     );
     await page.getByRole("link", { name: "Sign in" }).click();
     await expect(page).toHaveURL(/\/login$/);
@@ -54,6 +54,30 @@ test.describe("public product surface", () => {
     await expect(page.locator("html")).toHaveClass(/dark/);
     await page.keyboard.press("Tab");
     await expect(page.locator(":focus-visible")).toBeVisible();
+  });
+
+  test("mobile Sheet supports dismissal, resize, and sign-in navigation", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/");
+    const trigger = page.getByRole("button", { name: "Open navigation" });
+    await trigger.click();
+    const sheet = page.getByRole("dialog");
+    await expect(
+      sheet.getByRole("navigation", { name: "Mobile navigation" }),
+    ).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(sheet).not.toBeVisible();
+    await expect(trigger).toBeFocused();
+    await trigger.click();
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await expect(sheet).not.toBeVisible();
+    await page.setViewportSize({ width: 390, height: 844 });
+    await trigger.click();
+    await sheet.getByRole("link", { name: "Sign in", exact: true }).click();
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.getByLabel("Email")).toBeInViewport();
   });
 
   test("coming-soon redirects to signup", async ({ page }) => {

--- a/apps/web/modules/auth/auth-brand-specimen.tsx
+++ b/apps/web/modules/auth/auth-brand-specimen.tsx
@@ -5,7 +5,7 @@ const LINE_NUMBERS = ["01", "02", "03", "04", "05", "06"] as const;
 export const AuthBrandSpecimen = () => (
   <div
     aria-hidden="true"
-    className="mt-10 hidden w-full max-w-2xl border bg-card/75 shadow-[0_24px_80px_-48px_rgba(201,24,74,0.65)] lg:block"
+    className="mt-10 hidden w-full max-w-2xl rounded-xl border bg-card shadow-sm lg:block"
   >
     <div className="flex items-center gap-2 border-b px-3 py-2 font-mono text-[10px] text-muted-foreground">
       <Circle className="size-2.5 fill-primary text-primary" />
@@ -31,12 +31,11 @@ export const AuthBrandSpecimen = () => (
           A shared record of change
         </p>
         <p className="mt-3 max-w-lg text-xs leading-6 text-muted-foreground xl:text-sm">
-          Each insertion becomes a durable event. When Lina reconnects, repair
-          resumes after the last acknowledged cursor—without overwriting
-          Marco&apos;s concurrent paragraph.
+          A place for unfinished sentences, questions worth sitting with, and
+          ideas that get better together.
         </p>
         <blockquote className="mt-4 border-l-2 border-primary pl-4 text-xs italic xl:text-sm">
-          The document converges; the writers keep their context.
+          Make room for a new idea.
         </blockquote>
         <span className="absolute right-12 top-[6.8rem] h-5 border-l-2 border-teal-500" />
         <span className="absolute right-3 top-[7rem] bg-teal-600 px-1.5 py-0.5 font-mono text-[9px] text-white">

--- a/apps/web/modules/auth/auth-shell.tsx
+++ b/apps/web/modules/auth/auth-shell.tsx
@@ -13,7 +13,7 @@ export type AuthShellProps = {
 export const AuthShell = ({ children, description, title }: AuthShellProps) => (
   <main className="min-h-dvh bg-background text-foreground">
     <div className="mx-auto grid min-h-dvh w-full max-w-[96rem] lg:grid-cols-[minmax(0,1.08fr)_minmax(27rem,0.92fr)] lg:border-x">
-      <section className="flex min-w-0 flex-col px-5 py-6 sm:px-8 lg:min-h-dvh lg:px-12 lg:py-8 xl:px-16">
+      <section className="hidden min-w-0 flex-col px-5 py-6 sm:px-8 lg:flex lg:min-h-dvh lg:px-12 lg:py-8 xl:px-16">
         <div className="flex items-center justify-between gap-4">
           <Link
             className="rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -32,26 +32,26 @@ export const AuthShell = ({ children, description, title }: AuthShellProps) => (
         <div className="flex flex-1 flex-col justify-center py-12 sm:py-16 lg:py-12">
           <div className="h-px w-12 bg-primary" />
           <p className="mt-8 font-mono text-[10px] uppercase tracking-[0.24em] text-primary sm:text-xs">
-            Collaborative document infrastructure
+            A shared space for your words
           </p>
           <p className="mt-10 max-w-3xl font-display text-[clamp(2.75rem,11vw,5.5rem)] font-semibold leading-[0.88] tracking-[-0.055em]">
-            Ideas move.
+            A little space.
             <br />
-            The record
-            <br />
-            holds.
+            For big ideas.
           </p>
           <p className="mt-8 hidden max-w-xl text-sm leading-7 text-muted-foreground lg:block xl:text-base">
-            Softmaple is a high-density workspace for durable collaborative
-            writing, live presence, Markdown and LaTeX output, and deliberate
-            public sharing.
+            From the first rough note to the final paper. Write, shape, and
+            share your thinking, together.
           </p>
           <AuthBrandSpecimen />
         </div>
       </section>
 
-      <section className="flex min-w-0 items-center border-t bg-card/70 px-5 py-10 sm:px-8 sm:py-14 lg:min-h-dvh lg:border-l lg:border-t-0 lg:px-12 xl:px-16">
+      <section className="flex min-h-dvh min-w-0 items-center bg-card px-5 py-10 sm:px-8 sm:py-14 lg:border-l lg:px-12 xl:px-16">
         <div className="mx-auto w-full max-w-md">
+          <Link href="/" className="mb-10 inline-flex lg:hidden">
+            <SoftmapleWordmark className="text-2xl" />
+          </Link>
           <h1 className="font-display text-3xl font-semibold tracking-tight sm:text-4xl">
             {title}
           </h1>

--- a/apps/web/modules/dashboard/dashboard.tsx
+++ b/apps/web/modules/dashboard/dashboard.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import {
+  ArrowUpRight,
   Clock3,
   FileText,
   FolderPlus,
@@ -11,7 +12,16 @@ import {
   Users,
 } from "lucide-react";
 import { Button } from "@softmaple/ui/components/button";
-import { Input } from "@softmaple/ui/components/input";
+import { Badge } from "@softmaple/ui/components/badge";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@softmaple/ui/components/empty";
+import { SearchField } from "@/components/search-field";
 import { CreateWorkspaceDialog } from "@/modules/workspaces/create-workspace-dialog";
 import type { WorkspaceSummary } from "@/app/actions/workspaces";
 
@@ -22,109 +32,123 @@ export const Dashboard = ({
 }) => {
   const [searchQuery, setSearchQuery] = useState("");
   const [showCreateDialog, setShowCreateDialog] = useState(false);
-  const filteredWorkspaces = useMemo(() => {
-    const query = searchQuery.trim().toLowerCase();
-    if (query.length === 0) return workspaces;
-    return workspaces.filter(
-      (workspace) =>
-        workspace.title.toLowerCase().includes(query) ||
-        workspace.description?.toLowerCase().includes(query),
-    );
-  }, [searchQuery, workspaces]);
+  const query = searchQuery.trim().toLowerCase();
+  const filteredWorkspaces = workspaces.filter(
+    (workspace) =>
+      workspace.title.toLowerCase().includes(query) ||
+      workspace.description?.toLowerCase().includes(query),
+  );
 
   return (
-    <main className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-      <div className="mb-8 flex flex-col gap-5 border-b pb-7 sm:flex-row sm:items-end sm:justify-between">
+    <main className="mx-auto w-full max-w-7xl px-5 py-10 sm:px-8 lg:py-14">
+      <div className="mb-10 flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <p className="font-mono text-xs uppercase tracking-[0.2em] text-primary">
-            Workspace index
-          </p>
-          <h1 className="font-display mt-2 text-3xl font-semibold tracking-tight sm:text-4xl">
-            Your work, in motion.
+          <p className="text-sm text-muted-foreground">Your writing studio</p>
+          <h1 className="mt-3 font-display text-4xl font-semibold tracking-tight sm:text-5xl">
+            Room for your next idea.
           </h1>
-          <p className="mt-2 max-w-xl text-sm text-muted-foreground">
-            Open a shared writing space or start a new one.
+          <p className="mt-4 text-muted-foreground">
+            Pick up a shared project, or give a new thought a home.
           </p>
         </div>
         <Button onClick={() => setShowCreateDialog(true)}>
-          <Plus className="mr-2 h-4 w-4" /> New workspace
+          <Plus data-icon="inline-start" /> New workspace
         </Button>
       </div>
-
-      {workspaces.length === 0 ? (
-        <section className="grid min-h-80 place-items-center rounded-sm border border-dashed bg-card/60 p-8 text-center">
-          <div className="max-w-md">
-            <FolderPlus className="mx-auto h-10 w-10 text-primary" />
-            <h2 className="font-display mt-5 text-2xl font-semibold">
-              Create your first workspace
+      <section aria-labelledby="workspaces-heading">
+        <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <h2 id="workspaces-heading" className="text-lg font-semibold">
+              Your workspaces
             </h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              Workspaces keep documents, collaborators, and permissions
-              together.
-            </p>
-            <Button className="mt-6" onClick={() => setShowCreateDialog(true)}>
-              Create workspace
-            </Button>
+            <Badge variant="secondary">{workspaces.length}</Badge>
           </div>
-        </section>
-      ) : (
-        <>
-          <div className="relative mb-6 max-w-md">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              className="pl-9"
-              onChange={(event) => setSearchQuery(event.target.value)}
-              placeholder="Search workspaces"
-              value={searchQuery}
-            />
-          </div>
-          <div className="grid gap-px overflow-hidden rounded-sm border bg-border md:grid-cols-2 xl:grid-cols-3">
+          {workspaces.length > 0 ? (
+            <div className="w-full sm:max-w-xs">
+              <SearchField
+                label="Search workspaces"
+                value={searchQuery}
+                onChange={setSearchQuery}
+              />
+            </div>
+          ) : null}
+        </div>
+        {workspaces.length === 0 ? (
+          <Empty className="min-h-80 border">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <FolderPlus />
+              </EmptyMedia>
+              <EmptyTitle>Create your first workspace</EmptyTitle>
+              <EmptyDescription>
+                A home for your documents and the people you write with.
+              </EmptyDescription>
+            </EmptyHeader>
+            <EmptyContent>
+              <Button onClick={() => setShowCreateDialog(true)}>
+                Create workspace <ArrowUpRight data-icon="inline-end" />
+              </Button>
+            </EmptyContent>
+          </Empty>
+        ) : filteredWorkspaces.length === 0 ? (
+          <Empty className="min-h-72 border">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <Search />
+              </EmptyMedia>
+              <EmptyTitle>No workspaces found</EmptyTitle>
+              <EmptyDescription>
+                No workspace matches “{searchQuery}”. Try another name.
+              </EmptyDescription>
+            </EmptyHeader>
+            <EmptyContent>
+              <Button variant="outline" onClick={() => setSearchQuery("")}>
+                Clear search
+              </Button>
+            </EmptyContent>
+          </Empty>
+        ) : (
+          <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
             {filteredWorkspaces.map((workspace) => (
               <Link
-                className="group bg-card p-5 transition-colors hover:bg-accent"
+                className="group flex min-w-0 flex-col rounded-2xl border bg-card p-6 transition-[border-color,box-shadow] hover:border-primary/40 hover:shadow-md focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
                 href={`/workspace/${workspace.slug}`}
                 key={workspace.id}
               >
-                <div className="flex items-start justify-between gap-4">
-                  <div className="grid h-10 w-10 place-items-center rounded-sm border bg-background text-primary">
-                    <FileText className="h-5 w-5" />
-                  </div>
-                  <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
-                    Open workspace
+                <div className="flex items-center justify-between">
+                  <span className="grid size-12 place-items-center rounded-xl bg-secondary font-display text-xl font-semibold text-primary">
+                    {workspace.title.slice(0, 1).toUpperCase()}
                   </span>
+                  <ArrowUpRight className="size-5 text-muted-foreground transition-colors group-hover:text-primary" />
                 </div>
-                <h2 className="mt-8 text-lg font-semibold group-hover:text-primary">
+                <h3 className="mt-7 truncate font-display text-xl font-semibold tracking-tight">
                   {workspace.title}
-                </h2>
-                <p className="mt-1 min-h-10 text-sm text-muted-foreground">
-                  {workspace.description || "No description yet."}
+                </h3>
+                <p className="mt-2 line-clamp-2 min-h-12 text-sm leading-6 text-muted-foreground">
+                  {workspace.description ||
+                    "A shared space for your next chapter."}
                 </p>
-                <div className="mt-6 flex flex-wrap gap-4 border-t pt-4 font-mono text-xs text-muted-foreground">
+                <div className="mt-6 flex flex-wrap gap-x-5 gap-y-2 text-xs text-muted-foreground">
                   <span className="flex items-center gap-1.5">
-                    <FileText className="h-3.5 w-3.5" />
-                    {workspace.documentCount}
+                    <FileText className="size-3.5" />
+                    {workspace.documentCount} documents
                   </span>
                   <span className="flex items-center gap-1.5">
-                    <Users className="h-3.5 w-3.5" />
-                    {workspace.memberCount}
-                  </span>
-                  <span className="flex items-center gap-1.5">
-                    <Clock3 className="h-3.5 w-3.5" />
-                    {workspace.lastEditedAt === null
-                      ? "New"
-                      : new Date(workspace.lastEditedAt).toLocaleDateString()}
+                    <Users className="size-3.5" />
+                    {workspace.memberCount} members
                   </span>
                 </div>
+                <p className="mt-5 flex items-center gap-1.5 border-t pt-4 text-xs text-muted-foreground">
+                  <Clock3 className="size-3.5" />
+                  {workspace.lastEditedAt === null
+                    ? "Ready for the first word"
+                    : `Edited ${new Date(workspace.lastEditedAt).toLocaleDateString("en", { month: "short", day: "numeric", year: "numeric", timeZone: "UTC" })}`}
+                </p>
               </Link>
             ))}
           </div>
-          {filteredWorkspaces.length === 0 ? (
-            <p className="py-16 text-center text-sm text-muted-foreground">
-              No workspace matches “{searchQuery}”.
-            </p>
-          ) : null}
-        </>
-      )}
+        )}
+      </section>
       <CreateWorkspaceDialog
         open={showCreateDialog}
         onOpenChange={setShowCreateDialog}

--- a/apps/web/modules/workspaces/workspace-desktop-sidebar.tsx
+++ b/apps/web/modules/workspaces/workspace-desktop-sidebar.tsx
@@ -18,13 +18,13 @@ export const WorkspaceDesktopSidebar: FC<WorkspaceDesktopSidebarProps> = ({
   documents,
   workspaceSlug,
 }) => (
-  <aside className="hidden w-72 shrink-0 flex-col border-r bg-sidebar md:flex xl:w-80">
-    <div className="border-b p-4">
+  <aside className="hidden w-64 shrink-0 flex-col border-r bg-sidebar md:flex xl:w-72">
+    <div className="p-5">
       <Link
         className="mb-4 inline-flex rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
         href="/dashboard"
       >
-        <SoftmapleWordmark className="text-lg" />
+        <SoftmapleWordmark className="text-xl" />
       </Link>
       {children}
     </div>

--- a/apps/web/modules/workspaces/workspace-docs-list.tsx
+++ b/apps/web/modules/workspaces/workspace-docs-list.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import type { FC } from "react";
-import { useId, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { FileText, Plus, Search } from "lucide-react";
+import { FileText, Plus } from "lucide-react";
 import { Button } from "@softmaple/ui/components/button";
-import { Input } from "@softmaple/ui/components/input";
+import { SearchField } from "@/components/search-field";
 import { ScrollArea } from "@softmaple/ui/components/scroll-area";
 import type { DocsType } from "@/types/model";
 
@@ -26,7 +26,6 @@ export const WorkspaceDocsList: FC<WorkspaceDocsListProps> = ({
   workspaceSlug,
 }) => {
   const pathname = usePathname();
-  const searchId = useId();
   const [query, setQuery] = useState("");
   const filteredDocuments = useMemo(() => {
     const normalizedQuery = query.trim().toLocaleLowerCase();
@@ -39,19 +38,12 @@ export const WorkspaceDocsList: FC<WorkspaceDocsListProps> = ({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="border-b p-4">
-        <label className="relative block" htmlFor={searchId}>
-          <span className="sr-only">Search documents</span>
-          <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            className="pl-9"
-            id={searchId}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search documents"
-            type="search"
-            value={query}
-          />
-        </label>
+      <div className="px-4 pb-3">
+        <SearchField
+          label="Search documents"
+          value={query}
+          onChange={setQuery}
+        />
       </div>
 
       <div className="flex items-center justify-between px-4 pb-2 pt-4">
@@ -72,7 +64,7 @@ export const WorkspaceDocsList: FC<WorkspaceDocsListProps> = ({
               href={`/workspace/${workspaceSlug}/doc/new`}
               onClick={onNavigate}
             >
-              <Plus className="size-4" />
+              <Plus data-icon="inline-start" />
             </Link>
           </Button>
         ) : null}
@@ -86,7 +78,7 @@ export const WorkspaceDocsList: FC<WorkspaceDocsListProps> = ({
               : "No document matches this search."}
           </p>
         ) : (
-          <div className="space-y-0.5">
+          <div className="flex flex-col gap-1">
             {filteredDocuments.map((document) => {
               const path = `/workspace/${workspaceSlug}/doc/${document.slug}`;
               return (
@@ -96,7 +88,11 @@ export const WorkspaceDocsList: FC<WorkspaceDocsListProps> = ({
                   key={document.id}
                   variant={pathname === path ? "secondary" : "ghost"}
                 >
-                  <Link href={path} onClick={onNavigate}>
+                  <Link
+                    href={path}
+                    onClick={onNavigate}
+                    aria-current={pathname === path ? "page" : undefined}
+                  >
                     <FileText className="size-4 shrink-0 text-primary" />
                     <span className="min-w-0 flex-1">
                       <span className="block truncate text-sm">

--- a/apps/web/modules/workspaces/workspace-mobile-sidebar.tsx
+++ b/apps/web/modules/workspaces/workspace-mobile-sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { FC, ReactNode } from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Menu } from "lucide-react";
 import { Button } from "@softmaple/ui/components/button";
@@ -32,10 +32,18 @@ export const WorkspaceMobileSidebar: FC<WorkspaceMobileSidebarProps> = ({
 }) => {
   const [open, setOpen] = useState(false);
   const close = (): void => setOpen(false);
+  useEffect(() => {
+    const desktop = window.matchMedia("(min-width: 768px)");
+    const closeOnDesktop = () => {
+      if (desktop.matches) setOpen(false);
+    };
+    desktop.addEventListener("change", closeOnDesktop);
+    return () => desktop.removeEventListener("change", closeOnDesktop);
+  }, []);
 
   return (
     <Sheet onOpenChange={setOpen} open={open}>
-      <header className="flex h-14 shrink-0 items-center gap-2 border-b bg-background/90 px-3 backdrop-blur md:hidden">
+      <header className="flex h-16 shrink-0 items-center gap-2 border-b bg-background/90 px-3 backdrop-blur md:hidden">
         <SheetTrigger asChild>
           <Button
             aria-label="Open workspace navigation"
@@ -43,7 +51,7 @@ export const WorkspaceMobileSidebar: FC<WorkspaceMobileSidebarProps> = ({
             size="icon-sm"
             variant="outline"
           >
-            <Menu className="size-4" />
+            <Menu />
           </Button>
         </SheetTrigger>
         <div className="min-w-0 flex-1">{children}</div>

--- a/apps/web/modules/workspaces/workspace-navigation.tsx
+++ b/apps/web/modules/workspaces/workspace-navigation.tsx
@@ -20,7 +20,7 @@ export const WorkspaceNavigation: FC<WorkspaceNavigationProps> = (props) => {
   const isActive = (path: string) => pathname === path;
 
   return (
-    <div className="p-4 space-y-2">
+    <nav aria-label="Workspace sections" className="flex flex-col gap-1 p-4">
       <Button
         asChild
         className="w-full justify-start"
@@ -28,8 +28,14 @@ export const WorkspaceNavigation: FC<WorkspaceNavigationProps> = (props) => {
           isActive(`/workspace/${workspaceSlug}`) ? "secondary" : "ghost"
         }
       >
-        <Link href={`/workspace/${workspaceSlug}`} onClick={onNavigate}>
-          <Home className="mr-2 h-4 w-4" />
+        <Link
+          href={`/workspace/${workspaceSlug}`}
+          onClick={onNavigate}
+          aria-current={
+            isActive(`/workspace/${workspaceSlug}`) ? "page" : undefined
+          }
+        >
+          <Home data-icon="inline-start" />
           Overview
         </Link>
       </Button>
@@ -52,7 +58,7 @@ export const WorkspaceNavigation: FC<WorkspaceNavigationProps> = (props) => {
           onClick={onNavigate}
           prefetch={false}
         >
-          <Users className="mr-2 h-4 w-4" />
+          <Users data-icon="inline-start" />
           Members
         </Link>
       </Button>
@@ -70,10 +76,10 @@ export const WorkspaceNavigation: FC<WorkspaceNavigationProps> = (props) => {
           onClick={onNavigate}
           prefetch={false}
         >
-          <Settings className="mr-2 h-4 w-4" />
+          <Settings data-icon="inline-start" />
           Settings
         </Link>
       </Button>
-    </div>
+    </nav>
   );
 };

--- a/packages/ui/src/components/empty.tsx
+++ b/packages/ui/src/components/empty.tsx
@@ -1,0 +1,103 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@softmaple/ui/lib/utils";
+
+function Empty({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        "flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg border-dashed p-6 text-center text-balance md:p-12",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn(
+        "flex max-w-sm flex-col items-center gap-2 text-center",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const emptyMediaVariants = cva(
+  "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-6",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function EmptyMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant, className }))}
+      {...props}
+    />
+  );
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn("text-lg font-medium tracking-tight", className)}
+      {...props}
+    />
+  );
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        "text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        "flex w-full max-w-sm min-w-0 flex-col items-center gap-4 text-sm text-balance",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+  EmptyMedia,
+};

--- a/packages/ui/src/components/input-group.tsx
+++ b/packages/ui/src/components/input-group.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@softmaple/ui/lib/utils";
+
+import { Button } from "@softmaple/ui/components/button";
+import { Input } from "@softmaple/ui/components/input";
+import { Textarea } from "@softmaple/ui/components/textarea";
+
+function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-group"
+      role="group"
+      className={cn(
+        "group/input-group relative flex w-full items-center rounded-md border border-input shadow-xs transition-[color,box-shadow] outline-none dark:bg-input/30",
+        "h-9 min-w-0 has-[>textarea]:h-auto",
+
+        // Variants based on alignment.
+        "has-[>[data-align=inline-start]]:[&>input]:pl-2",
+        "has-[>[data-align=inline-end]]:[&>input]:pr-2",
+        "has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3",
+        "has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3",
+
+        // Focus state.
+        "has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-[3px] has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50",
+
+        // Error state.
+        "has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-destructive/20 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40",
+
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const inputGroupAddonVariants = cva(
+  "flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      align: {
+        "inline-start":
+          "order-first pl-3 has-[>button]:ml-[-0.45rem] has-[>kbd]:ml-[-0.35rem]",
+        "inline-end":
+          "order-last pr-3 has-[>button]:mr-[-0.45rem] has-[>kbd]:mr-[-0.35rem]",
+        "block-start":
+          "order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-2.5 [.border-b]:pb-3",
+        "block-end":
+          "order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-2.5 [.border-t]:pt-3",
+      },
+    },
+    defaultVariants: {
+      align: "inline-start",
+    },
+  },
+);
+
+function InputGroupAddon({
+  className,
+  align = "inline-start",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="input-group-addon"
+      data-align={align}
+      className={cn(inputGroupAddonVariants({ align }), className)}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest("button")) {
+          return;
+        }
+        e.currentTarget.parentElement?.querySelector("input")?.focus();
+      }}
+      {...props}
+    />
+  );
+}
+
+const inputGroupButtonVariants = cva(
+  "flex items-center gap-2 text-sm shadow-none",
+  {
+    variants: {
+      size: {
+        xs: "h-6 gap-1 rounded-[calc(var(--radius)-5px)] px-2 has-[>svg]:px-2 [&>svg:not([class*='size-'])]:size-3.5",
+        sm: "h-8 gap-1.5 rounded-md px-2.5 has-[>svg]:px-2.5",
+        "icon-xs":
+          "size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0",
+        "icon-sm": "size-8 p-0 has-[>svg]:p-0",
+      },
+    },
+    defaultVariants: {
+      size: "xs",
+    },
+  },
+);
+
+function InputGroupButton({
+  className,
+  type = "button",
+  variant = "ghost",
+  size = "xs",
+  ...props
+}: Omit<React.ComponentProps<typeof Button>, "size"> &
+  VariantProps<typeof inputGroupButtonVariants>) {
+  return (
+    <Button
+      type={type}
+      data-size={size}
+      variant={variant}
+      className={cn(inputGroupButtonVariants({ size }), className)}
+      {...props}
+    />
+  );
+}
+
+function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-2 text-sm text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function InputGroupInput({
+  className,
+  ...props
+}: React.ComponentProps<"input">) {
+  return (
+    <Input
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function InputGroupTextarea({
+  className,
+  ...props
+}: React.ComponentProps<"textarea">) {
+  return (
+    <Textarea
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none focus-visible:ring-0 dark:bg-transparent",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupInput,
+  InputGroupTextarea,
+};

--- a/packages/ui/src/components/input-group.tsx
+++ b/packages/ui/src/components/input-group.tsx
@@ -72,7 +72,9 @@ function InputGroupAddon({
         if ((e.target as HTMLElement).closest("button")) {
           return;
         }
-        e.currentTarget.parentElement?.querySelector("input")?.focus();
+        e.currentTarget.parentElement
+          ?.querySelector<HTMLElement>("[data-slot=input-group-control]")
+          ?.focus();
       }}
       {...props}
     />

--- a/packages/ui/src/components/kbd.tsx
+++ b/packages/ui/src/components/kbd.tsx
@@ -17,7 +17,7 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
 
 function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <kbd
+    <div
       data-slot="kbd-group"
       className={cn("inline-flex items-center gap-1", className)}
       {...props}

--- a/packages/ui/src/components/kbd.tsx
+++ b/packages/ui/src/components/kbd.tsx
@@ -1,0 +1,28 @@
+import { cn } from "@softmaple/ui/lib/utils";
+
+function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
+  return (
+    <kbd
+      data-slot="kbd"
+      className={cn(
+        "pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none",
+        "[&_svg:not([class*='size-'])]:size-3",
+        "[[data-slot=tooltip-content]_&]:bg-background/20 [[data-slot=tooltip-content]_&]:text-background dark:[[data-slot=tooltip-content]_&]:bg-background/10",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <kbd
+      data-slot="kbd-group"
+      className={cn("inline-flex items-center gap-1", className)}
+      {...props}
+    />
+  );
+}
+
+export { Kbd, KbdGroup };


### PR DESCRIPTION
## Changes proposed

Redesign the web app as a focused writing studio with blue ink and lavender surfaces, a manuscript-led landing page, clearer workspace cards, quieter navigation, and consistent light/dark themes. Mobile authentication now puts the form first.

- Add shadcn Sheet navigation to the public header; refine the existing workspace Sheet. Both close on desktop resize and retain accessible titles, dismissal, and focus restoration.
- Add shadcn Kbd and InputGroup to workspace/document searches: `/` focuses the visible search and Escape clears its query. Shortcuts respect typing, IME composition, modified keys, and hidden/modal-hidden sidebars.
- Add shadcn Empty states with a clear-search recovery action. Preserve existing workspace permissions, server actions, and collaboration behavior. No new package dependencies.

## Validation

- `pnpm --filter @softmaple/web build` — passed, including production TypeScript and static generation.
- `pnpm --filter @softmaple/web typecheck` — passed.
- `pnpm --filter @softmaple/web lint` and `pnpm --filter @softmaple/ui lint` — passed.
- `pnpm --filter @softmaple/web exec vitest run` — 23 files, 161 tests passed. The three new search tests also passed after correcting the test geometry mock.
- Playwright `e2e/public.spec.ts` against a local Next server — all five tests passed, including 320px layout, dark mode, Sheet dismissal/focus/resize, and mobile sign-in.
- Browser fixture checks: dashboard search/results/recovery/create dialog; workspace document filtering; slash preserved while typing; mobile Sheet search, Escape, focus restoration, and resizing. No page errors.

## Visual review

Captured and inspected desktop (1440px), mobile (390px), light/dark landing pages, dashboard cards, and both mobile Sheets. Screenshots are supplied with the accompanying Codex task; they are not added to application source.

Authenticated dashboard/workspace visual checks used temporary local fixture data; the fixture route was removed before the production build. Full seeded authentication/collaboration end-to-end tests were not rerun. Browser testing used Chromium through the installed Playwright package because the Browser plugin was unavailable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive site navigation with mobile menu support.
  * Added keyboard-friendly search fields with `/` focus and `Escape` clearing.
  * Added clearer dashboard empty states for no workspaces and no search results.
  * Added reusable empty-state, input-group, and keyboard-hint UI components.

* **Enhancements**
  * Refreshed landing, authentication, dashboard, and workspace experiences with updated messaging, layouts, spacing, colors, and accessibility.
  * Improved mobile navigation behavior and active document indicators.
  * Updated workspace and dashboard styling with softer corners and a blue/lavender visual theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->