### PR TITLE
feat(apps/web): redesign in an autumn theme and adopt the bottom sheet

### DIFF
--- a/apps/web/app/design.css
+++ b/apps/web/app/design.css
@@ -1,62 +1,88 @@
+/**
+ * Softmaple autumn theme.
+ *
+ * Light — "Parchment & Maple": warm paper stock, bark-brown ink, burnt maple
+ * accents. Dark — "Ember & Bark": deep bark ground lit by an amber ember.
+ * Every surface in the app reads from these tokens, so the season lives here
+ * and nowhere else.
+ */
+
 :root {
-  --background: #f7f8fc;
-  --foreground: #20263f;
-  --card: #ffffff;
-  --card-foreground: #20263f;
-  --popover: #ffffff;
-  --popover-foreground: #20263f;
-  --primary: #4859b8;
-  --primary-foreground: #ffffff;
-  --secondary: #edeff9;
-  --secondary-foreground: #20263f;
-  --muted: #edeff9;
-  --muted-foreground: #656d85;
-  --accent: #edeff9;
-  --accent-foreground: #20263f;
-  --destructive: #b42335;
-  --destructive-foreground: #ffffff;
-  --border: #dce0ed;
-  --input: #dce0ed;
-  --ring: #4859b8;
-  --sidebar: #ffffff;
-  --sidebar-foreground: #20263f;
-  --sidebar-primary: #4859b8;
-  --sidebar-primary-foreground: #ffffff;
-  --sidebar-accent: #edeff9;
-  --sidebar-accent-foreground: #20263f;
-  --sidebar-border: #dce0ed;
-  --sidebar-ring: #4859b8;
+  --background: #fbf6ee;
+  --foreground: #2b2019;
+  --card: #fffdf9;
+  --card-foreground: #2b2019;
+  --popover: #fffdf9;
+  --popover-foreground: #2b2019;
+  --primary: #b1451c;
+  --primary-foreground: #fff8f1;
+  --secondary: #f2e6d6;
+  --secondary-foreground: #2b2019;
+  --muted: #f2e6d6;
+  --muted-foreground: #6c574a;
+  --accent: #f7ded0;
+  --accent-foreground: #2b2019;
+  --destructive: #a3123a;
+  --destructive-foreground: #fff8f1;
+  --success: #4d6b2f;
+  --success-foreground: #fff8f1;
+  --border: #e5d3bd;
+  --input: #e0cab1;
+  --ring: #b1451c;
+  --sidebar: #fdf8f1;
+  --sidebar-foreground: #2b2019;
+  --sidebar-primary: #b1451c;
+  --sidebar-primary-foreground: #fff8f1;
+  --sidebar-accent: #f2e6d6;
+  --sidebar-accent-foreground: #2b2019;
+  --sidebar-border: #e5d3bd;
+  --sidebar-ring: #b1451c;
   --radius: 0.75rem;
+
+  /* Seasonal accents, for atmosphere rather than semantics. */
+  --autumn-ember: #c2521f;
+  --autumn-gold: #d59a2c;
+  --autumn-canopy: #8c3f1d;
+  --autumn-wash-strength: 14%;
+  --autumn-shadow: color-mix(in srgb, var(--autumn-canopy) 30%, transparent);
 }
 
 .dark {
-  --background: #141827;
-  --foreground: #eef0fa;
-  --card: #1c2235;
-  --card-foreground: #eef0fa;
-  --popover: #1c2235;
-  --popover-foreground: #eef0fa;
-  --primary: #acb8ff;
-  --primary-foreground: #141827;
-  --secondary: #252d45;
-  --secondary-foreground: #eef0fa;
-  --muted: #252d45;
-  --muted-foreground: #aab3cc;
-  --accent: #252d45;
-  --accent-foreground: #eef0fa;
-  --destructive: #fb7185;
-  --destructive-foreground: #141827;
-  --border: #353e59;
-  --input: #353e59;
-  --ring: #acb8ff;
-  --sidebar: #1c2235;
-  --sidebar-foreground: #eef0fa;
-  --sidebar-primary: #acb8ff;
-  --sidebar-primary-foreground: #141827;
-  --sidebar-accent: #252d45;
-  --sidebar-accent-foreground: #eef0fa;
-  --sidebar-border: #353e59;
-  --sidebar-ring: #acb8ff;
+  --background: #17120f;
+  --foreground: #f4e9dc;
+  --card: #211a15;
+  --card-foreground: #f4e9dc;
+  --popover: #241c17;
+  --popover-foreground: #f4e9dc;
+  --primary: #ef9a5c;
+  --primary-foreground: #24150c;
+  --secondary: #2d231c;
+  --secondary-foreground: #f4e9dc;
+  --muted: #2d231c;
+  --muted-foreground: #bda695;
+  --accent: #3a2a20;
+  --accent-foreground: #f7e2d0;
+  --destructive: #f2657f;
+  --destructive-foreground: #24150c;
+  --success: #a3c46a;
+  --success-foreground: #1b2410;
+  --border: #3b2f26;
+  --input: #47382d;
+  --ring: #ef9a5c;
+  --sidebar: #1c1611;
+  --sidebar-foreground: #f4e9dc;
+  --sidebar-primary: #ef9a5c;
+  --sidebar-primary-foreground: #24150c;
+  --sidebar-accent: #2d231c;
+  --sidebar-accent-foreground: #f4e9dc;
+  --sidebar-border: #3b2f26;
+  --sidebar-ring: #ef9a5c;
+
+  --autumn-ember: #e2703a;
+  --autumn-gold: #e0a94a;
+  --autumn-canopy: #f0a86a;
+  --autumn-wash-strength: 10%;
+  --autumn-shadow: #000000;
 }
 
 @theme inline {
@@ -74,10 +100,24 @@
     min-width: 320px;
     min-height: 100dvh;
     overflow-x: clip;
+    /* A low canopy light: ember from the left, late gold from the right. */
+    background-image:
+      radial-gradient(
+        58rem 38rem at 8% -14%,
+        color-mix(in srgb, var(--autumn-ember) var(--autumn-wash-strength), transparent),
+        transparent 60%
+      ),
+      radial-gradient(
+        46rem 32rem at 102% -6%,
+        color-mix(in srgb, var(--autumn-gold) var(--autumn-wash-strength), transparent),
+        transparent 58%
+      );
+    background-repeat: no-repeat;
+    background-attachment: fixed;
   }
 
   ::selection {
-    background: color-mix(in srgb, var(--primary) 28%, transparent);
+    background: color-mix(in srgb, var(--autumn-gold) 34%, transparent);
   }
 }
 
@@ -86,7 +126,18 @@
     position: relative;
     padding: 2rem 1.2rem 2.5rem;
     border-radius: 2rem;
-    background: var(--secondary);
+    background:
+      radial-gradient(
+        120% 90% at 85% 0%,
+        color-mix(in srgb, var(--autumn-gold) 22%, transparent),
+        transparent 58%
+      ),
+      radial-gradient(
+        95% 80% at 0% 100%,
+        color-mix(in srgb, var(--autumn-ember) 16%, transparent),
+        transparent 60%
+      ),
+      var(--secondary);
   }
 
   .manuscript-sheet {
@@ -94,7 +145,7 @@
     border: 1px solid var(--border);
     border-radius: 0.9rem;
     background: var(--card);
-    box-shadow: 0 22px 45px -25px color-mix(in srgb, var(--primary) 35%, transparent);
+    box-shadow: 0 24px 48px -26px var(--autumn-shadow);
     transform: rotate(-2deg);
   }
 
@@ -111,7 +162,7 @@
     padding: 0.8rem 1rem;
     color: var(--primary);
     font-size: 0.75rem;
-    box-shadow: 0 4px 16px color-mix(in srgb, var(--foreground) 6%, transparent);
+    box-shadow: 0 6px 18px -6px var(--autumn-shadow);
   }
 
   .markdown-preview {

--- a/apps/web/components/site-header.tsx
+++ b/apps/web/components/site-header.tsx
@@ -74,8 +74,8 @@ export function SiteHeader() {
                 <Menu />
               </Button>
             </SheetTrigger>
-            <SheetContent className="w-[min(22rem,90vw)] overflow-y-auto">
-              <SheetHeader>
+            <SheetContent className="gap-0" side="bottom">
+              <SheetHeader className="pb-2">
                 <SheetTitle>
                   <SoftmapleWordmark className="text-xl" />
                 </SheetTitle>
@@ -83,31 +83,34 @@ export function SiteHeader() {
               </SheetHeader>
               <nav
                 aria-label="Mobile navigation"
-                className="flex flex-col gap-2 px-4"
+                className="flex flex-col gap-1 px-4"
               >
                 {links.map((link) => (
                   <Button
                     asChild
                     variant="ghost"
-                    className="justify-start"
+                    className="h-11 justify-between px-3 text-base"
                     key={link.label}
                   >
                     <a href={link.href} onClick={() => setOpen(false)}>
                       {link.label}
-                      <ArrowUpRight data-icon="inline-end" />
+                      <ArrowUpRight
+                        className="text-muted-foreground"
+                        data-icon="inline-end"
+                      />
                     </a>
                   </Button>
                 ))}
               </nav>
-              <div className="mt-auto flex flex-col gap-3 p-4">
-                <Button asChild variant="outline">
-                  <Link href="/login" onClick={() => setOpen(false)}>
-                    Sign in
+              <div className="mt-4 flex flex-col gap-3 border-t p-4">
+                <Button asChild size="lg">
+                  <Link href="/signup" onClick={() => setOpen(false)}>
+                    Start writing <ArrowUpRight data-icon="inline-end" />
                   </Link>
                 </Button>
-                <Button asChild>
-                  <Link href="/signup" onClick={() => setOpen(false)}>
-                    Start writing
+                <Button asChild size="lg" variant="outline">
+                  <Link href="/login" onClick={() => setOpen(false)}>
+                    Sign in
                   </Link>
                 </Button>
               </div>

--- a/apps/web/modules/auth/auth-brand-specimen.tsx
+++ b/apps/web/modules/auth/auth-brand-specimen.tsx
@@ -10,7 +10,7 @@ export const AuthBrandSpecimen = () => (
     <div className="flex items-center gap-2 border-b px-3 py-2 font-mono text-[10px] text-muted-foreground">
       <Circle className="size-2.5 fill-primary text-primary" />
       field-notes / carbon-cycle
-      <span className="ml-auto flex items-center gap-1 text-teal-600 dark:text-teal-400">
+      <span className="ml-auto flex items-center gap-1 text-success">
         <Check className="size-3" /> Saved
       </span>
     </div>
@@ -37,8 +37,8 @@ export const AuthBrandSpecimen = () => (
         <blockquote className="mt-4 border-l-2 border-primary pl-4 text-xs italic xl:text-sm">
           Make room for a new idea.
         </blockquote>
-        <span className="absolute right-12 top-[6.8rem] h-5 border-l-2 border-teal-500" />
-        <span className="absolute right-3 top-[7rem] bg-teal-600 px-1.5 py-0.5 font-mono text-[9px] text-white">
+        <span className="absolute right-12 top-[6.8rem] h-5 border-l-2 border-success" />
+        <span className="absolute right-3 top-[7rem] bg-success px-1.5 py-0.5 font-mono text-[9px] text-success-foreground">
           Lina
         </span>
       </div>

--- a/apps/web/modules/docs/doc-header.tsx
+++ b/apps/web/modules/docs/doc-header.tsx
@@ -56,7 +56,7 @@ const STATUS_COPY: Readonly<
   connecting: { label: "Connecting", tone: "text-muted-foreground" },
   syncing: { label: "Syncing", tone: "text-amber-600 dark:text-amber-400" },
   saving: { label: "Saving", tone: "text-amber-600 dark:text-amber-400" },
-  saved: { label: "Saved", tone: "text-teal-600 dark:text-teal-400" },
+  saved: { label: "Saved", tone: "text-success" },
   offline: { label: "Offline", tone: "text-orange-600 dark:text-orange-400" },
   error: { label: "Error", tone: "text-destructive" },
 };

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -6,6 +6,29 @@ import { XIcon } from "lucide-react";
 
 import { cn } from "@softmaple/ui/lib/utils";
 
+const SheetSide = {
+  Top: "top",
+  Right: "right",
+  Bottom: "bottom",
+  Left: "left",
+} as const;
+
+type SheetSide = (typeof SheetSide)[keyof typeof SheetSide];
+
+/**
+ * Edge-specific geometry and motion. Bottom and top sheets are capped and
+ * scrollable so long content never runs past the viewport, and both round the
+ * corners that face into the page.
+ */
+const sheetSideStyles: Readonly<Record<SheetSide, string>> = {
+  top: "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 max-h-[85dvh] overflow-y-auto rounded-b-2xl border-b pt-[env(safe-area-inset-top)]",
+  right:
+    "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+  bottom:
+    "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 max-h-[85dvh] overflow-y-auto rounded-t-2xl border-t pb-[env(safe-area-inset-bottom)]",
+  left: "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+};
+
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />;
 }
@@ -36,7 +59,7 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50 backdrop-blur-[2px]",
         className,
       )}
       {...props}
@@ -44,38 +67,71 @@ function SheetOverlay({
   );
 }
 
+/**
+ * A tap target that sits where a thumb already is. It reads as the drag
+ * affordance people expect on a bottom sheet and closes on activation, so the
+ * grabber is a real control rather than decoration.
+ */
+function SheetHandle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return (
+    <SheetPrimitive.Close
+      data-slot="sheet-handle"
+      className={cn(
+        "group bg-background focus-visible:ring-ring sticky top-0 z-10 -mb-2 flex shrink-0 items-center justify-center pt-3 pb-2 outline-none focus-visible:ring-2 focus-visible:ring-inset",
+        className,
+      )}
+      {...props}
+    >
+      <span className="bg-muted-foreground/35 group-hover:bg-muted-foreground/60 h-1.5 w-10 rounded-full transition-colors" />
+      <span className="sr-only">Close</span>
+    </SheetPrimitive.Close>
+  );
+}
+
+type SheetContentProps = React.ComponentProps<typeof SheetPrimitive.Content> & {
+  /** Edge the sheet is anchored to. Defaults to `right`. */
+  readonly side?: SheetSide;
+  /** Grabber affordance. Defaults to on for bottom sheets, off elsewhere. */
+  readonly showHandle?: boolean;
+  /** Corner dismiss button. Defaults to on wherever the grabber is not shown. */
+  readonly showCloseButton?: boolean;
+};
+
 function SheetContent({
   className,
   children,
-  side = "right",
+  side = SheetSide.Right,
+  showHandle,
+  showCloseButton,
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Content> & {
-  side?: "top" | "right" | "bottom" | "left";
-}) {
+}: SheetContentProps) {
+  const hasHandle = showHandle ?? side === SheetSide.Bottom;
+  const hasCloseButton = showCloseButton ?? !hasHandle;
+
   return (
     <SheetPortal>
       <SheetOverlay />
       <SheetPrimitive.Content
         data-slot="sheet-content"
+        data-side={side}
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
-          side === "right" &&
-            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
-          side === "left" &&
-            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
-          side === "top" &&
-            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
-          side === "bottom" &&
-            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-200 data-[state=open]:duration-300",
+          sheetSideStyles[side],
           className,
         )}
         {...props}
       >
+        {hasHandle ? <SheetHandle /> : null}
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-          <XIcon className="size-4" />
-          <span className="sr-only">Close</span>
-        </SheetPrimitive.Close>
+        {hasCloseButton ? (
+          <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        ) : null}
       </SheetPrimitive.Content>
     </SheetPortal>
   );
@@ -132,8 +188,11 @@ export {
   SheetTrigger,
   SheetClose,
   SheetContent,
+  SheetHandle,
   SheetHeader,
   SheetFooter,
+  SheetSide,
   SheetTitle,
   SheetDescription,
 };
+export type { SheetContentProps };

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -25,6 +25,8 @@
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.577 0.245 27.325);
+  --success: oklch(0.52 0.12 145);
+  --success-foreground: oklch(0.985 0 0);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
@@ -61,6 +63,8 @@
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.396 0.141 25.723);
   --destructive-foreground: oklch(0.637 0.237 25.331);
+  --success: oklch(0.76 0.14 145);
+  --success-foreground: oklch(0.205 0 0);
   --border: oklch(0.269 0 0);
   --input: oklch(0.269 0 0);
   --ring: oklch(0.556 0 0);
@@ -96,6 +100,8 @@
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);


### PR DESCRIPTION
The bottom side previously reused the plain drawer treatment: square
corners, no height cap, and a corner X that a thumb cannot comfortably
reach. Give each edge its own geometry through a lookup keyed by a const
object, and treat bottom (and top) as capped, scrollable surfaces that
round the corners facing into the page and respect the device safe area.

Bottom sheets now get a grabber instead of the corner X. It is a real
SheetPrimitive.Close with an accessible name rather than a decorative
pill, so the affordance people expect at the bottom of a phone screen
actually does something, and it sticks to the top of the scroll area so
it stays reachable in a long sheet.

Also adds a semantic success token to the design system so apps can
express a "saved"/"healthy" state without hardcoding a palette color.

Both new props (showHandle, showCloseButton) derive their defaults from
the side, so existing callers are unaffected.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018QWQKvDCikMkGqUqfFWjPq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added success-themed status styling for saved indicators and collaborator labels.
  * Improved sheets with side-specific layouts, scrolling, rounded corners, backdrop blur, and optional handles or close buttons.
* **Style**
  * Updated the visual theme with a warm autumn color palette, ambient gradients, and refreshed selection and shadow styling.
  * Restyled mobile navigation with a bottom-opening panel, clearer header content, and improved action layout.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->