### PR TITLE
feat(apps/web): move workspace mobile navigation to a bottom sheet

### DIFF
--- a/apps/web/app/workspace/[workspaceSlug]/layout.tsx
+++ b/apps/web/app/workspace/[workspaceSlug]/layout.tsx
@@ -8,7 +8,7 @@ import { requireWorkspaceRouteData } from "@/lib/actions/workspace-route";
 import { WORKSPACE_ROLE } from "@/lib/workspace-roles";
 import { WorkspaceDesktopSidebar } from "@/modules/workspaces/workspace-desktop-sidebar";
 import { WorkspaceDropdown } from "@/modules/workspaces/workspace-dropdown";
-import { WorkspaceMobileSidebar } from "@/modules/workspaces/workspace-mobile-sidebar";
+import { WorkspaceMobileNav } from "@/modules/workspaces/workspace-mobile-nav";
 
 type Props = {
   params: Promise<{ workspaceSlug: string }>;
@@ -58,18 +58,6 @@ export default async function WorkspaceLayoutPage(props: Props) {
 
   return (
     <div className="flex h-dvh min-h-0 min-w-0 flex-col overflow-hidden bg-background md:flex-row">
-      <WorkspaceMobileSidebar
-        canEdit={canEdit}
-        documents={documents}
-        workspaceSlug={workspaceSlug}
-      >
-        <WorkspaceDropdown
-          compact
-          workspaceSlug={workspaceSlug}
-          workspaces={workspaces}
-        />
-      </WorkspaceMobileSidebar>
-
       <WorkspaceDesktopSidebar
         canEdit={canEdit}
         documents={documents}
@@ -84,6 +72,23 @@ export default async function WorkspaceLayoutPage(props: Props) {
       <div className="flex min-h-0 min-w-0 flex-1 flex-col">
         <Suspense>{children}</Suspense>
       </div>
+
+      {/*
+        Last in the column so the mobile bar lands at the bottom of the shell
+        and the content keeps the reading order; `md:hidden` retires it once
+        the desktop sidebar takes over.
+      */}
+      <WorkspaceMobileNav
+        canEdit={canEdit}
+        documents={documents}
+        workspaceSlug={workspaceSlug}
+      >
+        <WorkspaceDropdown
+          compact
+          workspaceSlug={workspaceSlug}
+          workspaces={workspaces}
+        />
+      </WorkspaceMobileNav>
     </div>
   );
 }

--- a/apps/web/modules/workspaces/workspace-mobile-nav.test.tsx
+++ b/apps/web/modules/workspaces/workspace-mobile-nav.test.tsx
@@ -17,14 +17,23 @@ vi.mock("next/link", () => ({
   default: ({
     children,
     href,
-    prefetch: _prefetch,
+    prefetch,
     ...props
   }: {
     readonly children: ReactNode;
     readonly href: string;
     readonly onClick?: () => void;
     readonly prefetch?: boolean;
-  }) => createElement("a", { href, ...props }, children),
+  }) =>
+    createElement(
+      "a",
+      {
+        href,
+        "data-prefetch": prefetch === undefined ? "default" : String(prefetch),
+        ...props,
+      },
+      children,
+    ),
 }));
 
 const documents: ReadonlyArray<DocsType["Row"]> = [

--- a/apps/web/modules/workspaces/workspace-mobile-nav.test.tsx
+++ b/apps/web/modules/workspaces/workspace-mobile-nav.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+
+import { act, createElement, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DocsType } from "@/types/model";
+import { WorkspaceMobileNav } from "./workspace-mobile-nav";
+
+const usePathname = vi.hoisted(() => vi.fn(() => "/workspace/acme"));
+
+vi.mock("next/navigation", () => ({
+  usePathname,
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    prefetch: _prefetch,
+    ...props
+  }: {
+    readonly children: ReactNode;
+    readonly href: string;
+    readonly onClick?: () => void;
+    readonly prefetch?: boolean;
+  }) => createElement("a", { href, ...props }, children),
+}));
+
+const documents: ReadonlyArray<DocsType["Row"]> = [
+  {
+    author_id: "author-1",
+    created_at: "2026-01-01T00:00:00.000Z",
+    created_by: null,
+    id: "doc-1",
+    is_public: false,
+    slug: "field-notes",
+    title: "Field notes",
+    updated_at: "2026-01-02T00:00:00.000Z",
+    updated_by: null,
+    workspace_id: 1,
+  },
+];
+
+const renderNav = (container: HTMLDivElement) => {
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      createElement(WorkspaceMobileNav, {
+        canEdit: true,
+        documents,
+        workspaceSlug: "acme",
+      }),
+    );
+  });
+  return root;
+};
+
+const menuButton = (container: HTMLDivElement): HTMLButtonElement => {
+  const button = container.querySelector<HTMLButtonElement>(
+    'button[aria-label="Open workspace navigation"]',
+  );
+  if (button === null) throw new Error("menu button is not rendered");
+  return button;
+};
+
+const sheet = (): HTMLElement | null =>
+  document.body.querySelector<HTMLElement>('[data-slot="sheet-content"]');
+
+describe("WorkspaceMobileNav", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    );
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    usePathname.mockReturnValue("/workspace/acme");
+  });
+
+  afterEach(() => {
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("puts the menu button in a bar that closes the shell rather than a header", () => {
+    const root = renderNav(container);
+
+    const bar = menuButton(container).closest("nav");
+    expect(bar?.getAttribute("aria-label")).toBe("Workspace");
+    expect(bar?.className).toContain("border-t");
+    expect(bar?.className).toContain("md:hidden");
+    expect(container.querySelector("header")).toBeNull();
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("opens the navigation as a bottom sheet with a grabber", () => {
+    const root = renderNav(container);
+    expect(sheet()).toBeNull();
+
+    act(() => {
+      menuButton(container).click();
+    });
+
+    expect(sheet()?.getAttribute("data-side")).toBe("bottom");
+    expect(
+      document.body.querySelector('[data-slot="sheet-handle"]'),
+    ).not.toBeNull();
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("closes the sheet once a destination inside it is chosen", () => {
+    const root = renderNav(container);
+    act(() => {
+      menuButton(container).click();
+    });
+
+    const documentLink = document.body.querySelector<HTMLAnchorElement>(
+      'a[href="/workspace/acme/doc/field-notes"]',
+    );
+    expect(documentLink).not.toBeNull();
+    act(() => {
+      documentLink?.click();
+    });
+
+    expect(sheet()).toBeNull();
+
+    act(() => {
+      root.unmount();
+    });
+  });
+});

--- a/apps/web/modules/workspaces/workspace-mobile-nav.tsx
+++ b/apps/web/modules/workspaces/workspace-mobile-nav.tsx
@@ -56,12 +56,17 @@ export const WorkspaceMobileNav: FC<WorkspaceMobileNavProps> = ({
         aria-label="Workspace"
         className="shrink-0 border-t bg-background/90 pb-[env(safe-area-inset-bottom)] backdrop-blur md:hidden"
       >
-        <div className="flex h-16 items-center gap-2 px-3">
-          <div className="min-w-0 flex-1">{children}</div>
+        {/*
+          Three tracks rather than a flex row: the empty trailing track
+          balances the workspace switcher, so the menu button is centered
+          against the viewport instead of against whatever space is left over.
+          The 0 minimum keeps a long workspace title from stealing that space.
+        */}
+        <div className="grid h-16 grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2 px-3">
+          <div className="min-w-0">{children}</div>
           <SheetTrigger asChild>
             <Button
               aria-label="Open workspace navigation"
-              className="shrink-0"
               size="icon-lg"
               variant="outline"
             >

--- a/apps/web/modules/workspaces/workspace-mobile-nav.tsx
+++ b/apps/web/modules/workspaces/workspace-mobile-nav.tsx
@@ -17,14 +17,19 @@ import { SoftmapleWordmark } from "@/components/BrandMark";
 import { WorkspaceDocsList } from "@/modules/workspaces/workspace-docs-list";
 import { WorkspaceNavigation } from "@/modules/workspaces/workspace-navigation";
 
-export type WorkspaceMobileSidebarProps = {
+export type WorkspaceMobileNavProps = {
   readonly canEdit: boolean;
   readonly children?: ReactNode;
   readonly documents: ReadonlyArray<DocsType["Row"]>;
   readonly workspaceSlug: string;
 };
 
-export const WorkspaceMobileSidebar: FC<WorkspaceMobileSidebarProps> = ({
+/**
+ * Mobile workspace chrome: a bar pinned to the bottom of the shell whose menu
+ * button opens the navigation tree as a bottom sheet, so the trigger and the
+ * surface it reveals both sit under the thumb rather than at arm's reach.
+ */
+export const WorkspaceMobileNav: FC<WorkspaceMobileNavProps> = ({
   canEdit,
   children,
   documents,
@@ -43,28 +48,42 @@ export const WorkspaceMobileSidebar: FC<WorkspaceMobileSidebarProps> = ({
 
   return (
     <Sheet onOpenChange={setOpen} open={open}>
-      <header className="flex h-16 shrink-0 items-center gap-2 border-b bg-background/90 px-3 backdrop-blur md:hidden">
-        <SheetTrigger asChild>
-          <Button
-            aria-label="Open workspace navigation"
-            className="shrink-0"
-            size="icon-sm"
-            variant="outline"
-          >
-            <Menu />
-          </Button>
-        </SheetTrigger>
-        <div className="min-w-0 flex-1">{children}</div>
-      </header>
+      {/*
+        The bar is a flex sibling of the scrolling content rather than a fixed
+        overlay, so the shell reserves its height and nothing hides behind it.
+      */}
+      <nav
+        aria-label="Workspace"
+        className="shrink-0 border-t bg-background/90 pb-[env(safe-area-inset-bottom)] backdrop-blur md:hidden"
+      >
+        <div className="flex h-16 items-center gap-2 px-3">
+          <div className="min-w-0 flex-1">{children}</div>
+          <SheetTrigger asChild>
+            <Button
+              aria-label="Open workspace navigation"
+              className="shrink-0"
+              size="icon-lg"
+              variant="outline"
+            >
+              <Menu />
+            </Button>
+          </SheetTrigger>
+        </div>
+      </nav>
+      {/*
+        A definite height (not just the side's cap) gives the document list a
+        resolvable flex basis, so it scrolls inside the sheet instead of
+        stretching it. Scrolling stays with that list, hence overflow-y-hidden.
+      */}
       <SheetContent
-        className="flex h-dvh min-h-0 w-[min(20rem,90vw)] flex-col gap-0 p-0"
-        side="left"
+        className="flex h-[85dvh] min-h-0 flex-col gap-0 overflow-y-hidden"
+        side="bottom"
       >
         <SheetTitle className="sr-only">Workspace navigation</SheetTitle>
         <SheetDescription className="sr-only">
           Browse workspace sections and documents.
         </SheetDescription>
-        <div className="shrink-0 border-b p-4">
+        <div className="shrink-0 border-b px-4 pb-3 pt-2">
           <Link
             className="inline-flex rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
             href="/dashboard"


### PR DESCRIPTION
The workspace shell put its mobile chrome in a top header: a menu button
and the workspace switcher an arm's reach away, opening a full-height
left drawer. The rest of the app moved to bottom sheets in #915; the
workspace was the surface left behind.

The bar now sits at the foot of the shell and its menu button opens the
navigation tree as a bottom sheet, so the trigger and the surface it
reveals are both under the thumb. Sheet already treats the bottom edge as
a first-class side, so the drawer arrives with the grabber, the rounded
top corners, and the safe-area padding for free.

The bar is a flex sibling of the scrolling content rather than a fixed
overlay, so the shell reserves its height and no document scrolls behind
it, and it comes last in the column so the content keeps the reading
order. The sheet takes a definite height instead of only the side's cap,
which gives the document list a resolvable flex basis: it scrolls inside
the sheet rather than stretching it.

Renamed from workspace-mobile-sidebar since it is no longer a sidebar.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JoSnd9J4uMPVEhkKaUNWnN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated workspace navigation on mobile with a bottom navigation bar.
  - The navigation menu now opens as a bottom sheet with a fixed height and independently scrollable content.
  - Selecting a document automatically closes the navigation sheet.
  - Desktop workspace navigation remains available while the mobile navigation is hidden on medium and larger screens.
- **Tests**
  - Added coverage for mobile navigation visibility, menu opening, bottom-sheet behavior, and link selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->